### PR TITLE
fix: prevent duplicate message display for new contacts

### DIFF
--- a/src/uPtt/ui/screens.py
+++ b/src/uPtt/ui/screens.py
@@ -647,6 +647,8 @@ class MainWindow(QMainWindow):
             self.chat_histories[sender] = []
             self.unread_counts[sender] = 0
             # 如果是新聯絡人，新增到清單 (帶入原始大小寫 ID 與 暱稱)
+            # add_or_select_contact 內部會呼叫 on_contact_selected，
+            # 後者已從 DB 載入訊息並呼叫 refresh_chat_display，不需再 append。
             self.add_or_select_contact(sender_id_display, nickname)
         else:
             # 如果已存在，更新暱稱與 ID (以防對方改過大小寫或暱稱)
@@ -656,26 +658,26 @@ class MainWindow(QMainWindow):
                 if widget.ptt_id == sender:
                     widget.update_info(sender_id_display, nickname)
                     break
-            
-        self.chat_histories[sender].append({
-            'text': data['text'], 
-            'time': data['time'], 
-            'timestamp': data.get('timestamp', datetime.now()), # 優先使用 Worker 傳來的時間
-            'is_me': False
-        })
-        
-        if self.current_chat_id == sender:
-            self.refresh_chat_display()
-        else:
-            self.unread_counts[sender] += 1
-            # 更新清單中的未讀計數
-            for i in range(self.contact_list.count()):
-                item = self.contact_list.item(i)
-                widget = self.contact_list.itemWidget(item)
-                if widget.ptt_id == sender:
-                    widget.set_unread(self.unread_counts[sender])
-                    break
-        
+
+            self.chat_histories[sender].append({
+                'text': data['text'],
+                'time': data['time'],
+                'timestamp': data.get('timestamp', datetime.now()),
+                'is_me': False
+            })
+
+            if self.current_chat_id == sender:
+                self.refresh_chat_display()
+            else:
+                self.unread_counts[sender] += 1
+                # 更新清單中的未讀計數
+                for i in range(self.contact_list.count()):
+                    item = self.contact_list.item(i)
+                    widget = self.contact_list.itemWidget(item)
+                    if widget.ptt_id == sender:
+                        widget.set_unread(self.unread_counts[sender])
+                        break
+
         # 桌面通知 (顯示原始大小寫 ID)
         if not self.isActiveWindow():
             self.tray_icon.showMessage(

--- a/tests/test_ui_screens.py
+++ b/tests/test_ui_screens.py
@@ -141,9 +141,9 @@ def test_on_new_message_blocked(mock_qthread, mock_worker, qtbot, ptt_service_mo
     with patch('os.path.exists', return_value=True):
         window = MainWindow(ptt_service_mock, db_mock)
         qtbot.addWidget(window)
-        
+
         window.blocked_users.add("baduser")
-        
+
         # Simulate new message from blocked user
         msg_data = {
             'sender': 'BadUser',
@@ -152,7 +152,45 @@ def test_on_new_message_blocked(mock_qthread, mock_worker, qtbot, ptt_service_mo
             'full_author': 'BadUser (BadGuy)'
         }
         window.on_new_message(msg_data)
-        
+
         # Should NOT be added to history or list
         assert "baduser" not in window.chat_histories
         assert window.contact_list.count() == 0
+
+@patch('src.uPtt.ui.screens.PTTWorker')
+@patch('src.uPtt.ui.screens.QThread')
+def test_on_new_message_new_contact_no_duplicate(mock_qthread, mock_worker, qtbot, ptt_service_mock, db_mock):
+    """新聯絡人第一次傳訊息時，訊息不應重複出現在 chat_histories"""
+    from datetime import datetime
+    with patch('os.path.exists', return_value=True):
+        ptt_service_mock.ptt_id = "MyID"
+
+        # 模擬 DB 已有這則訊息（worker 先存入 DB 後才發射 signal）
+        msg_time = datetime(2026, 3, 17, 7, 59, 0)
+        db_mock.get_messages.return_value = [{
+            'content': '安安，Mac 封測中',
+            'timestamp': msg_time,
+            'is_me': 0,
+            'sender_id': 'codingman',
+            'receiver_id': 'myid',
+        }]
+        db_mock.get_all_sessions.return_value = []
+
+        window = MainWindow(ptt_service_mock, db_mock)
+        qtbot.addWidget(window)
+
+        # 確認 codingman 不在 chat_histories（全新聯絡人）
+        assert 'codingman' not in window.chat_histories
+
+        msg_data = {
+            'sender': 'CodingMan',
+            'text': '安安，Mac 封測中',
+            'time': '07:59',
+            'full_author': 'CodingMan (bug maker)',
+            'timestamp': msg_time,
+        }
+        window.on_new_message(msg_data)
+
+        # 修復後：chat_histories 只應有 1 筆（由 on_contact_selected 從 DB 載入）
+        assert 'codingman' in window.chat_histories
+        assert len(window.chat_histories['codingman']) == 1


### PR DESCRIPTION
## Summary

- When a message arrived from a **new contact** (not yet in `chat_histories`), `on_new_message` called `add_or_select_contact`, which internally triggered `on_contact_selected`
- `on_contact_selected` already loaded the message from DB and called `refresh_chat_display` (1st render)
- The code then continued to `append` the same message again and re-render (2nd render), causing the duplicate

## Root Cause

`screens.py` — `on_new_message`: the `append` + `refresh_chat_display` calls were outside the `if/else` block, so they executed unconditionally even after the new-contact path had already rendered via DB load.

## Fix

Moved `append` and `refresh_chat_display` into the `else` branch (existing contact path only). The new contact path now relies solely on `on_contact_selected` to load messages from DB — no manual append needed.

## Test Plan

- [x] Added `test_on_new_message_new_contact_no_duplicate` to `tests/test_ui_screens.py`
- [x] All 32 tests pass (`pytest`)
- [x] Manually verified: login with empty DB → receive message from new contact → message appears exactly once