### PR TITLE
fix: correct metadata variable name in setup.py to match __init__.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-__pycache__
+__pycache__/
 .idea/
 build/
 dist/
@@ -9,3 +9,6 @@ coverage.xml
 *.log
 *.db
 .claude/
+*.egg-info/
+.pytest_cache/
+*.pyc

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("requirements.txt", "r", encoding="utf-8") as f:
     requirements = f.read().splitlines()
 
 setuptools.setup(
-    name=about['__name__'],
+    name=about['__app_name__'],
     version=about['__version__'],
     author=about['__author__'],
     author_email=about['__author_email__'],


### PR DESCRIPTION
### Summary
修正了 `setup.py` 無法讀取專案中繼資料（Metadata）的問題。此問題會導致在執行 `pip install .` 或建立開發環境時出現 `KeyError` 錯誤。

### Changes
* **`setup.py`**: 將 `name=about['__name__']` 修正為 `name=about['__app_name__']`，以對應 `src/uPtt/__init__.py` 中的變數定義。
* **`.gitignore`**: 補充了 `*.egg-info/`, `*.pyc`, `.pytest_cache/` 等編譯與測試產生的暫存檔目錄，保持工作區整潔。

### Verification
* [x] 成功建立 `.venv` 並透過 `pip install -e .` 完成安裝。
* [x] 執行 `pytest` 測試，131 個測試項目全數通過。
* [x] 本地環境已確認能正常啟動 `uptt`。