### PR TITLE
fix(linux): optimize input method support for Wayland

### DIFF
--- a/src/uPtt/app.py
+++ b/src/uPtt/app.py
@@ -13,6 +13,44 @@ from .ui.screens import MainWindow
 from . import utils
 
 
+def setup_linux_im():
+    """在 Linux 環境下優化輸入法 (IM) 支援"""
+    if sys.platform == "linux":
+        is_wayland = os.environ.get("XDG_SESSION_TYPE") == "wayland"
+
+        # 在 Wayland 環境下，如果不設定 QT_IM_MODULE，Qt 6 通常能透過 Wayland 協定更好地支援輸入法
+        # 但有些使用者環境已經預設設定了 fcitx (通常是針對 X11)，這反而可能導致 Qt 6 無法在 Wayland 下輸入
+        if is_wayland:
+            curr_im = os.environ.get("QT_IM_MODULE")
+            if curr_im and curr_im in ["fcitx", "ibus"]:
+                logger.info(f"偵測到 Wayland 環境，將清除不相容的 QT_IM_MODULE ({curr_im}) 以使用原生支援")
+                os.environ.pop("QT_IM_MODULE", None)
+
+            # 過濾 Wayland 文字輸入產生的瑣碎偵錯訊息 (qt.qpa.wayland.textinput)
+            if "QT_LOGGING_RULES" not in os.environ:
+                os.environ["QT_LOGGING_RULES"] = "qt.qpa.wayland.textinput=false"
+            else:
+                os.environ["QT_LOGGING_RULES"] += ";qt.qpa.wayland.textinput=false"
+        else:
+            # 如果使用者沒有手動設定 QT_IM_MODULE，嘗試自動設定常見值
+            if "QT_IM_MODULE" not in os.environ:
+                if os.path.exists("/usr/bin/ibus"):
+                    os.environ["QT_IM_MODULE"] = "ibus"
+                elif os.path.exists("/usr/bin/fcitx") or os.path.exists("/usr/bin/fcitx5"):
+                    os.environ["QT_IM_MODULE"] = "fcitx"
+                # 某些環境可能需要 wayland 作為 IM 模組
+                elif os.environ.get("XDG_SESSION_TYPE") == "wayland":
+                    os.environ["QT_IM_MODULE"] = "wayland"
+
+        # 確保 XMODIFIERS 也有設定 (IBus/Fcitx 需要)
+        if "XMODIFIERS" not in os.environ:
+            im_module = os.environ.get("QT_IM_MODULE")
+            if im_module == "ibus":
+                os.environ["XMODIFIERS"] = "@im=ibus"
+            elif im_module == "fcitx":
+                os.environ["XMODIFIERS"] = "@im=fcitx"
+
+
 # --- 日誌設定 ---
 def setup_logging(debug_mode: bool):
     """設定日誌系統，確保同時輸出到終端機與檔案"""
@@ -60,6 +98,7 @@ def main():
     parser.add_argument("--debug", action="store_true", help="啟用除錯模式並記錄至檔案")
     args = parser.parse_args()
 
+    setup_linux_im()
     setup_logging(args.debug)
 
     # 初始化 Qt 應用程式

--- a/src/uPtt/app.py
+++ b/src/uPtt/app.py
@@ -38,9 +38,7 @@ def setup_linux_im():
                     os.environ["QT_IM_MODULE"] = "ibus"
                 elif os.path.exists("/usr/bin/fcitx") or os.path.exists("/usr/bin/fcitx5"):
                     os.environ["QT_IM_MODULE"] = "fcitx"
-                # 某些環境可能需要 wayland 作為 IM 模組
-                elif os.environ.get("XDG_SESSION_TYPE") == "wayland":
-                    os.environ["QT_IM_MODULE"] = "wayland"
+
 
         # 確保 XMODIFIERS 也有設定 (IBus/Fcitx 需要)
         if "XMODIFIERS" not in os.environ:
@@ -98,8 +96,8 @@ def main():
     parser.add_argument("--debug", action="store_true", help="啟用除錯模式並記錄至檔案")
     args = parser.parse_args()
 
-    setup_linux_im()
     setup_logging(args.debug)
+    setup_linux_im()
 
     # 初始化 Qt 應用程式
     qt_app = QApplication(sys.argv)


### PR DESCRIPTION
Optimizes Chinese input method support on Wayland by unsetting QT_IM_MODULE when it conflicts with Qt 6 native Wayland text-input support. Also suppresses noisy Wayland log messages.