### PR TITLE
feat: 增加 Linux (Ubuntu) 自動編譯發行與本地驗證腳本

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -278,6 +278,117 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  build-linux:
+    needs: [prepare-version]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Patch version in source
+        run: |
+          VERSION="${{ needs.prepare-version.outputs.VERSION }}"
+          python -c "
+          import re, pathlib
+          f = pathlib.Path('src/uPtt/__init__.py')
+          f.write_text(re.sub(r'__version__ = \".*?\"', '__version__ = \"$VERSION\"', f.read_text()))
+          "
+          echo "RELEASE_TITLE=${{ needs.prepare-version.outputs.RELEASE_TITLE }}" >> $GITHUB_ENV
+
+      - name: Install system dependencies (Linux Qt6)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libegl1 libopengl0 libxkbcommon-x11-0 libdbus-1-3 libxcb-cursor0 \
+            libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 \
+            libxcb-xinerama0 libxcb-xfixes0 libxcb-shape0 librsvg2-bin patchelf
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+          pip install nuitka zstandard
+
+      - name: Cache Nuitka (Linux)
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/Nuitka
+          key: nuitka-linux-${{ hashFiles('src/**/*.py', 'requirements.txt') }}
+          restore-keys: nuitka-linux-
+
+      - name: Build with Nuitka (standalone)
+        run: |
+          PYTHONPATH=src python -m nuitka \
+            --standalone \
+            --plugin-enable=pyside6 \
+            --include-qt-plugins=sensible \
+            --include-package=PyPtt \
+            --include-package=websockets \
+            --include-package=qasync \
+            --include-package-data=uPtt.ui.assets \
+            --output-dir=dist \
+            --output-filename=uptt \
+            src/run_app.py
+
+      - name: Rename standalone folder and binary
+        run: |
+          if [ -d "dist/run_app.dist" ]; then
+            mv dist/run_app.dist dist/uPtt
+          fi
+          # 不再需要手動改名執行檔，因為編譯時已指定 --output-filename
+          if [ -f "dist/uPtt/uptt" ]; then
+            chmod +x dist/uPtt/uptt
+          fi
+
+      - name: Smoke test Linux binary
+        run: |
+          if [ ! -f "dist/uPtt/uptt" ]; then
+            echo "ERROR: dist/uPtt/uptt not found"
+            ls -R dist/
+            exit 1
+          fi
+          echo "Smoke testing: dist/uPtt/uptt"
+          # 使用 QT_QPA_PLATFORM=offscreen 確保在無介面環境下能執行
+          QT_QPA_PLATFORM=offscreen ./dist/uPtt/uptt --debug &
+          BG_PID=$!
+          sleep 10
+          if kill -0 "$BG_PID" 2>/dev/null; then
+            kill "$BG_PID"
+            echo "Smoke test passed (binary was still running after 10s)"
+          else
+            wait "$BG_PID"
+            EXIT_CODE=$?
+            if [ "$EXIT_CODE" -ne 0 ]; then
+              echo "ERROR: Binary crashed with exit code $EXIT_CODE"
+              exit 1
+            fi
+            echo "Smoke test passed (binary exited cleanly)"
+          fi
+
+      - name: Package for distribution
+        run: |
+          cd dist
+          tar -czf uPtt-Linux.tar.gz uPtt/
+
+      - name: Create or Update Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/uPtt-Linux.tar.gz
+          tag_name: v${{ needs.prepare-version.outputs.VERSION }}
+          name: ${{ env.RELEASE_TITLE }}
+          prerelease: ${{ needs.prepare-version.outputs.IS_PRERELEASE }}
+          draft: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build-windows:
     needs: [prepare-version]
     runs-on: windows-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-__pycache__
+__pycache__/
 .idea/
 build/
 dist/
@@ -9,3 +9,6 @@ coverage.xml
 *.log
 *.db
 .claude/
+*.egg-info/
+.pytest_cache/
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__/
 .idea/
 build/
 dist/
+dist_local/
 .DS_Store
 *venv*/
 coverage.xml

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/uPtt-messenger/uPttTerm/blob/main/LICENSE"><img src="https://img.shields.io/badge/授權條款-GPL--3.0-green.svg" alt="License"></a>
-  <img src="https://img.shields.io/badge/平台-Windows%20|%20macOS-lightgrey" alt="Platform">
+  <img src="https://img.shields.io/badge/平台-Windows%20|%20macOS%20|%20Linux-lightgrey" alt="Platform">
   <a href="https://uptt-messenger.github.io/uPtt-app/"><img src="https://img.shields.io/badge/官方網站-uPtt-A0C4B4?style=flat&logo=github" alt="Website"></a>
 </p>
 
@@ -93,6 +93,7 @@ PTT（批踢踢）是台灣最具生命力的網路社群，但傳統的 Telnet 
 
 *   **Windows:** 下載 `.exe` 執行檔，執行後即可啟動。
 *   **macOS:** 下載 `.dmg` 映像檔，將 `uPtt` 拖移至「應用程式」資料夾即可使用。
+*   **Linux (Ubuntu/Debian):** 下載 `.tar.gz` 壓縮檔，解壓後執行 `./uptt` 即可。
 
 ---
 
@@ -104,6 +105,7 @@ PTT（批踢踢）是台灣最具生命力的網路社群，但傳統的 Telnet 
 2.  **安裝依賴：** `pip install -r requirements.txt`
 3.  **執行：** `python3 src/run_app.py`
 4.  **測試：** `pytest --cov=src/uPtt tests/`
+5.  **Linux 編譯驗證：** `./scripts/local_build_linux.sh`
 
 ---
 

--- a/README_en.md
+++ b/README_en.md
@@ -9,7 +9,7 @@
 
 <p align="center">
   <a href="https://github.com/uPtt-messenger/uPttTerm/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-GPL--3.0-green.svg" alt="License"></a>
-  <img src="https://img.shields.io/badge/Platform-Windows%20|%20macOS-lightgrey" alt="Platform">
+  <img src="https://img.shields.io/badge/Platform-Windows%20|%20macOS%20|%20Linux-lightgrey" alt="Platform">
   <a href="https://uptt-messenger.github.io/uPtt-app/"><img src="https://img.shields.io/badge/Website-uPtt-A0C4B4?style=flat&logo=github" alt="Website"></a>
 </p>
 
@@ -93,6 +93,7 @@ Head to [GitHub Releases](https://github.com/uPtt-messenger/uPtt-app/releases) t
 
 * **Windows:** Download the `.exe` file and run it.
 * **macOS:** Download the `.dmg` file and drag `uPtt` to your Applications folder.
+* **Linux (Ubuntu/Debian):** Download the `.tar.gz` file, extract, and run `./uptt`.
 
 ---
 
@@ -104,6 +105,7 @@ Built with **Python 3.12** and **PySide6**. To set up a development environment:
 2. **Install dependencies:** `pip install -r requirements.txt`
 3. **Run:** `python3 src/run_app.py`
 4. **Test:** `pytest --cov=src/uPtt tests/`
+5. **Verify Linux Build:** `./scripts/local_build_linux.sh`
 
 ---
 

--- a/scripts/local_build_linux.sh
+++ b/scripts/local_build_linux.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# scripts/local_build_linux.sh
+
+# 確保在專案根目錄執行
+cd "$(dirname "$0")/.."
+
+# 檢查系統是否有 patchelf (Nuitka Standalone Linux 必備)
+if ! command -v patchelf &> /dev/null; then
+    echo "錯誤: 系統未安裝 'patchelf'。"
+    echo "Nuitka 於 Linux 建立獨立執行檔 (standalone) 時需要此工具。"
+    echo "請執行以下指令進行安裝："
+    echo "  sudo apt update && sudo apt install -y patchelf"
+    exit 1
+fi
+
+# 檢查虛擬環境是否存在，若無則自動建立並安裝依賴
+if [ ! -d ".venv" ]; then
+    echo "偵測到找不到 .venv，正在自動建立虛擬環境並安裝依賴套件 (這可能需要一點時間)..."
+    python3 -m venv .venv
+    if [ $? -ne 0 ]; then
+        echo "錯誤: 建立虛擬環境失敗。請確保系統已安裝 python3-venv。"
+        exit 1
+    fi
+    source .venv/bin/activate
+    echo "正在升級 pip..."
+    pip install --upgrade pip
+    echo "正在安裝專案依賴項目..."
+    pip install -r requirements.txt
+    pip install -r requirements-dev.txt
+    echo "正在安裝編譯器相關套件..."
+    pip install nuitka zstandard
+else
+    # 啟動虛擬環境
+    source .venv/bin/activate
+fi
+
+# 設定路徑讓 Nuitka 能找到原始碼
+export PYTHONPATH=src
+
+# 執行 Nuitka 編譯 (Standalone 模式)
+echo "正在開始本地編譯 (Standalone 模式)..."
+# 注意：使用 --output-filename 指定執行檔名稱，避免手動改名導致路徑偵測失敗
+python -m nuitka \
+    --standalone \
+    --plugin-enable=pyside6 \
+    --include-qt-plugins=sensible \
+    --include-package=PyPtt \
+    --include-package=websockets \
+    --include-package=qasync \
+    --include-package-data=uPtt.ui.assets \
+    --output-dir=dist_local \
+    --output-filename=uptt \
+    --assume-yes-for-downloads \
+    src/run_app.py
+
+# 檢查編譯是否成功
+if [ $? -ne 0 ]; then
+    echo "編譯失敗！"
+    exit 1
+fi
+
+# 整理產出物名稱 (與 CI/CD 流程一致)
+echo "正在整理產出物..."
+if [ -d "dist_local/run_app.dist" ]; then
+    # 如果已存在舊的 uPtt 資料夾則先移除
+    rm -rf dist_local/uPtt
+    mv dist_local/run_app.dist dist_local/uPtt
+fi
+
+# 確保執行檔具備執行權限 (雖然 Nuitka 預設會給)
+if [ -f "dist_local/uPtt/uptt" ]; then
+    chmod +x dist_local/uPtt/uptt
+fi
+
+# 打包為 .tar.gz (與 CI 流程一致)
+echo "正在打包為 uPtt-Linux.tar.gz..."
+tar -czf dist_local/uPtt-Linux.tar.gz -C dist_local uPtt/
+
+echo "===================================================="
+echo "編譯完成！"
+echo "1. 執行檔路徑：dist_local/uPtt/uptt"
+echo "2. 壓縮檔路徑：dist_local/uPtt-Linux.tar.gz"
+echo ""
+echo "您可以執行以下命令啟動測試 (debug 模式)："
+echo "  ./dist_local/uPtt/uptt --debug"
+echo "===================================================="

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("requirements.txt", "r", encoding="utf-8") as f:
     requirements = f.read().splitlines()
 
 setuptools.setup(
-    name=about['__name__'],
+    name=about['__app_name__'],
     version=about['__version__'],
     author=about['__author__'],
     author_email=about['__author_email__'],

--- a/src/uPtt/ui/screens.py
+++ b/src/uPtt/ui/screens.py
@@ -452,6 +452,7 @@ class MainWindow(QMainWindow):
         self._user_info_cache: Dict[str, Dict] = {}  # ptt_id_lower -> user info dict
         self.session_drafts: Dict[str, str] = {}  # ptt_id_lower -> draft text
         self._pending_send_targets: collections.deque = collections.deque()  # FIFO queue of send targets
+        self._quitting = False  # 退出程序旗標，防止遞迴
 
         # 初始化 UI 與背景執行緒
         self.init_ui()
@@ -1846,6 +1847,10 @@ class MainWindow(QMainWindow):
 
     def fully_quit(self):
         """徹底退出程式，確保 PTT 登出與執行緒釋放"""
+        if self._quitting:
+            return
+        self._quitting = True
+
         logger.info("正在執行完全退出程序...")
         try:
             self._stop_all_threads()


### PR DESCRIPTION
### 🛠️ 變更概要
本 PR 為 `uPtt-app` 正式引入了對 Linux 平台（尤其是 Ubuntu）的建置支援，讓跨平台發布流程更加完整。

1.  **CI/CD 工作流更新 (build.yml)**:
    *   新增 `build-linux` 工作任務，支援自動編譯並上傳 `.tar.gz` 至 Release。
    *   自動安裝 `patchelf` 與 `librsvg2-bin` 等 Linux 必要建置工具。
    *   修正了 Linux 上檔案與資料夾命名衝突的問題（將執行檔統一命名為小寫 `uptt`）。
2.  **新增本地編譯腳本 (scripts/local_build_linux.sh)**:
    *   支援自動初始化 `.venv` 環境與安裝依賴。
    *   模擬 CI 流程進行 Standalone 編譯與 `.tar.gz` 打包。
    *   具備環境前置檢查（如 `patchelf` 偵測）。
3.  **基礎穩定性修復**:
    *   修復了 `MainWindow.fully_quit` 中的無限遞迴問題（此部分與 #15 重疊）。
4.  **文件更新**:
    *   更新 `README.md` 與 `README_en.md` 以正式宣佈支援 Linux 平台。

### 📦 依賴說明
> [!IMPORTANT]
> **本 PR 包含並依賴於以下 PR 的修復：**
> *   **PR #15** (fix(ui): prevent recursion in MainWindow.fully_quit)
> 
> 這是因為 Linux 版在啟動異常時會觸發退出程序，若不包含此修正會導致 Core Dump，因此在開發過程中已預先併入。

### ✅ 驗證紀錄
*   **本地驗證**：在 Ubuntu 24.04 環境下透過 `local_build_linux.sh` 編譯成功，且解壓後執行 `./uptt` 運作正常（已驗證圖形介面啟動與 PTT 連線）。
*   **CI 驗證**：工作流語法已通過檢查。