### PR TITLE
fix: harden linux build script and add fully_quit regression test

### DIFF
--- a/scripts/local_build_linux.sh
+++ b/scripts/local_build_linux.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # scripts/local_build_linux.sh
+set -euo pipefail
 
 # 確保在專案根目錄執行
 cd "$(dirname "$0")/.."
@@ -16,11 +17,10 @@ fi
 # 檢查虛擬環境是否存在，若無則自動建立並安裝依賴
 if [ ! -d ".venv" ]; then
     echo "偵測到找不到 .venv，正在自動建立虛擬環境並安裝依賴套件 (這可能需要一點時間)..."
-    python3 -m venv .venv
-    if [ $? -ne 0 ]; then
+    python3 -m venv .venv || {
         echo "錯誤: 建立虛擬環境失敗。請確保系統已安裝 python3-venv。"
         exit 1
-    fi
+    }
     source .venv/bin/activate
     echo "正在升級 pip..."
     pip install --upgrade pip
@@ -52,12 +52,6 @@ python -m nuitka \
     --output-filename=uptt \
     --assume-yes-for-downloads \
     src/run_app.py
-
-# 檢查編譯是否成功
-if [ $? -ne 0 ]; then
-    echo "編譯失敗！"
-    exit 1
-fi
 
 # 整理產出物名稱 (與 CI/CD 流程一致)
 echo "正在整理產出物..."

--- a/tests/test_ui_screens.py
+++ b/tests/test_ui_screens.py
@@ -239,6 +239,22 @@ def test_fully_quit(mock_qthread, mock_worker, mock_query_worker, mock_ver_worke
         # Should call invokeMethod for worker.stop
         mock_invoke.assert_called()
 
+@patch('PySide6.QtCore.QMetaObject.invokeMethod')
+@patch('src.uPtt.ui.screens.VersionCheckWorker')
+@patch('src.uPtt.ui.screens.QueryWorker')
+@patch('src.uPtt.ui.screens.PTTWorker')
+@patch('src.uPtt.ui.screens.QThread')
+def test_fully_quit_is_reentrant_safe(mock_qthread, mock_worker, mock_query_worker, mock_ver_worker, mock_invoke, qtbot, ptt_service_mock, ptt_query_service_mock, db_mock):
+    # Regression: closeEvent can re-fire during QApplication.quit tear-down,
+    # so fully_quit must short-circuit on re-entry (see PRs #15 / #17).
+    with patch('os.path.exists', return_value=True):
+        window = MainWindow(ptt_service_mock, ptt_query_service_mock, db_mock)
+        qtbot.addWidget(window)
+        window._stop_all_threads = MagicMock()
+        window.fully_quit()
+        window.fully_quit()
+        assert window._stop_all_threads.call_count == 1
+
 def test_render_svg_exists():
     from src.uPtt.ui.screens import render_svg
     with open("test_pixmap.svg", "w") as f:


### PR DESCRIPTION
## Summary
Follow-up to #17 addressing review nits:

- **`scripts/local_build_linux.sh`** — add `set -euo pipefail` so silent failures in `pip install` / `tar` / `source activate` no longer mask broken builds. Convert the two post-hoc `if [ \$? -ne 0 ]` checks to `||` / implicit-exit (now redundant under `set -e`).
- **`tests/test_ui_screens.py`** — add `test_fully_quit_is_reentrant_safe`. The `_quitting` guard has now been patched twice (#15 / #17); this test locks it in so it can't regress a third time.

## Test plan
- [x] `bash -n scripts/local_build_linux.sh` — syntax OK
- [x] `QT_QPA_PLATFORM=offscreen pytest tests/` — 132 passed (coverage 69.75%)
- [ ] (Deferred) verify script on Ubuntu 24.04 — not gating, logic change is local to error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)