### PR TITLE
feat(build): switch linux build to onefile mode and optimize cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -324,10 +324,10 @@ jobs:
           key: nuitka-linux-${{ hashFiles('src/**/*.py', 'requirements.txt') }}
           restore-keys: nuitka-linux-
 
-      - name: Build with Nuitka (standalone)
+      - name: Build with Nuitka (onefile)
         run: |
           PYTHONPATH=src python -m nuitka \
-            --standalone \
+            --onefile \
             --plugin-enable=pyside6 \
             --include-qt-plugins=sensible \
             --include-package=PyPtt \
@@ -336,14 +336,18 @@ jobs:
             --include-package-data=uPtt.ui.assets \
             --output-dir=dist \
             --output-filename=uptt \
+            --assume-yes-for-downloads \
             src/run_app.py
 
-      - name: Rename standalone folder and binary
+      - name: Organize onefile binary and set permissions
         run: |
-          if [ -d "dist/run_app.dist" ]; then
-            mv dist/run_app.dist dist/uPtt
+          rm -rf dist/uPtt
+          mkdir -p dist/uPtt
+          
+          if [ -f "dist/uptt" ]; then
+            mv dist/uptt dist/uPtt/
           fi
-          # 不再需要手動改名執行檔，因為編譯時已指定 --output-filename
+          
           if [ -f "dist/uPtt/uptt" ]; then
             chmod +x dist/uPtt/uptt
           fi

--- a/scripts/local_build_linux.sh
+++ b/scripts/local_build_linux.sh
@@ -37,11 +37,14 @@ fi
 # 設定路徑讓 Nuitka 能找到原始碼
 export PYTHONPATH=src
 
-# 執行 Nuitka 編譯 (Standalone 模式)
-echo "正在開始本地編譯 (Standalone 模式)..."
+# 清除舊的編譯快取與產出，避免分支切換或舊檔案干擾
+rm -rf dist_local/*.build dist_local/*.onefile-build dist_local/uPtt dist_local/uptt
+
+# 執行 Nuitka 編譯 (onefile 模式)
+echo "正在開始本地編譯 (onefile 模式)..."
 # 注意：使用 --output-filename 指定執行檔名稱，避免手動改名導致路徑偵測失敗
 python -m nuitka \
-    --standalone \
+    --onefile \
     --plugin-enable=pyside6 \
     --include-qt-plugins=sensible \
     --include-package=PyPtt \
@@ -55,10 +58,13 @@ python -m nuitka \
 
 # 整理產出物名稱 (與 CI/CD 流程一致)
 echo "正在整理產出物..."
-if [ -d "dist_local/run_app.dist" ]; then
-    # 如果已存在舊的 uPtt 資料夾則先移除
-    rm -rf dist_local/uPtt
-    mv dist_local/run_app.dist dist_local/uPtt
+# 建立一個 uPtt 目錄來存放這唯一的執行檔，保持與 CI 流程結構一致
+rm -rf dist_local/uPtt
+mkdir -p dist_local/uPtt
+
+# onefile 產出的檔案會直接位於 --output-dir 下
+if [ -f "dist_local/uptt" ]; then
+    mv dist_local/uptt dist_local/uPtt/
 fi
 
 # 確保執行檔具備執行權限 (雖然 Nuitka 預設會給)


### PR DESCRIPTION
## 變更說明
將 Linux 平台的 Nuitka 編譯模式從 `--standalone` 切換為 `--onefile`。

## 變更原因
此變更是為了解決 `standalone` 模式編譯在中文路徑環境下執行時可能遇到的 Core Dump 問題。改用 `onefile` 模式可避開特定路徑編碼導致的加載錯誤。
參考討論：https://github.com/Nuitka/Nuitka/issues/3825

## 修改細節
1. **模式切換**：.github/workflows/build.yml 與 scripts/local_build_linux.sh 同步改為 `--onefile`。
2. **清理優化**：改進了本地編譯腳本的清理邏輯，確保每次編譯皆為乾淨狀態。
3. **穩定性提升**：加入 `--assume-yes-for-downloads` 以確保 CI 流程不會因下載提示而中斷。

## 驗證結果
- 本地 Pytest 測試：132 passed (100%)。
- Linux 編譯測試：成功產生可於中文路徑下正常啟動之單一執行檔。
