### PR TITLE
fix: PTT native reply silently dropped due to substring title match

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PySide6~=6.8.2.1
 qasync~=0.27.1
-pyptt~=2.0.8
+pyptt~=2.0.9
 packaging~=24.2
 requests~=2.33.0

--- a/src/uPtt/worker.py
+++ b/src/uPtt/worker.py
@@ -153,7 +153,7 @@ class PTTWorker(QObject):
 
         raw_title = mail.get(PyPtt.MailField.title)
         title = str(raw_title) if raw_title is not None else ""
-        is_uptt_msg = contant.PTT_MSG_TITLE in title
+        is_uptt_msg = (title == contant.PTT_MSG_TITLE)
 
         if not is_uptt_msg:
             # 一般站內信
@@ -306,7 +306,7 @@ class PTTWorker(QObject):
 
                 raw_title = mail.get(PyPtt.MailField.title)
                 title = str(raw_title) if raw_title is not None else ""
-                is_uptt_msg = contant.PTT_MSG_TITLE in title
+                is_uptt_msg = (title == contant.PTT_MSG_TITLE)
 
                 if is_uptt_msg:
                     found_uptt = True
@@ -413,7 +413,7 @@ class PTTWorker(QObject):
 
                 raw_title = mail.get(PyPtt.MailField.title)
                 title = str(raw_title) if raw_title is not None else ""
-                is_uptt_msg = contant.PTT_MSG_TITLE in title
+                is_uptt_msg = (title == contant.PTT_MSG_TITLE)
 
                 if is_uptt_msg:
                     found_uptt = True


### PR DESCRIPTION
## Summary

- PTT 原生回信標題格式為 `Re: 你收到使用 uPtt 傳送的訊息`，舊的子字串比對 (`in`) 仍會 match，誤判為 uPtt 格式
- Division line 解析失敗後訊息被 silently drop，既不顯示為 uPtt 訊息也不顯示為一般站內信
- 將三處 `contant.PTT_MSG_TITLE in title` 改為精確比對 `title == contant.PTT_MSG_TITLE`，讓非 uPtt 回信走一般站內信路徑正常顯示

## Test plan

- [ ] 讓另一個 PTT 帳號從 PTT 原生介面對 uPtt 訊息按「回信」，確認 uPtt 收到後以 mail card 顯示
- [ ] 確認一般 uPtt ↔ uPtt 訊息收發不受影響
- [ ] `pytest tests/test_worker.py` 全 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)