### PR TITLE
fix: stop stripping QT_IM_MODULE on Wayland, fixing Chinese input on Ubuntu 24.04

### DIFF
--- a/src/uPtt/app.py
+++ b/src/uPtt/app.py
@@ -18,14 +18,7 @@ def setup_linux_im():
     if sys.platform == "linux":
         is_wayland = os.environ.get("XDG_SESSION_TYPE") == "wayland"
 
-        # 在 Wayland 環境下，如果不設定 QT_IM_MODULE，Qt 6 通常能透過 Wayland 協定更好地支援輸入法
-        # 但有些使用者環境已經預設設定了 fcitx (通常是針對 X11)，這反而可能導致 Qt 6 無法在 Wayland 下輸入
         if is_wayland:
-            curr_im = os.environ.get("QT_IM_MODULE")
-            if curr_im and curr_im in ["fcitx", "ibus"]:
-                logger.info(f"偵測到 Wayland 環境，將清除不相容的 QT_IM_MODULE ({curr_im}) 以使用原生支援")
-                os.environ.pop("QT_IM_MODULE", None)
-
             # 過濾 Wayland 文字輸入產生的瑣碎偵錯訊息 (qt.qpa.wayland.textinput)
             if "QT_LOGGING_RULES" not in os.environ:
                 os.environ["QT_LOGGING_RULES"] = "qt.qpa.wayland.textinput=false"

--- a/src/uPtt/app.py
+++ b/src/uPtt/app.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+import shutil
 import sys
 import os
 
@@ -27,10 +28,10 @@ def setup_linux_im():
         else:
             # 如果使用者沒有手動設定 QT_IM_MODULE，嘗試自動設定常見值
             if "QT_IM_MODULE" not in os.environ:
-                if os.path.exists("/usr/bin/ibus"):
+                if shutil.which("ibus"):
                     os.environ["QT_IM_MODULE"] = "ibus"
-                elif os.path.exists("/usr/bin/fcitx") or os.path.exists("/usr/bin/fcitx5"):
-                    os.environ["QT_IM_MODULE"] = "fcitx"
+                elif shutil.which("fcitx5") or shutil.which("fcitx"):
+                    os.environ["QT_IM_MODULE"] = "fcitx"  # fcitx5 的 Qt module 名稱仍為 "fcitx"
 
 
         # 確保 XMODIFIERS 也有設定 (IBus/Fcitx 需要)


### PR DESCRIPTION
## Summary

- Removed logic in `setup_linux_im()` that unconditionally stripped `QT_IM_MODULE=ibus` (or `fcitx`) on Wayland sessions
- The old assumption — that Qt6's native `zwp_text_input_v3` Wayland protocol would handle input — fails on Ubuntu 24.04, which ships ibus 1.5.29 with incomplete Wayland text-input-v3 support
- The system-set `QT_IM_MODULE` value is now preserved, letting ibus/fcitx5 work normally on Wayland

## Root cause

Ubuntu 24.04 defaults to Wayland + GNOME + ibus. The system sets `QT_IM_MODULE=ibus` in `/etc/environment`. Our code removed it on Wayland, leaving Qt6 with no usable input method bridge, breaking all CJK input.

## Test plan

- [ ] Launch on Ubuntu 24.04 (Wayland session) with ibus active — confirm Chinese input works in the message box
- [ ] Launch on Ubuntu with X11 session — confirm auto-detection still sets `QT_IM_MODULE` if unset
- [ ] Launch on non-Linux platform — no regression expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)