### PR TITLE
feat: redesign marketing site with light/dark themes and app mockups

### DIFF
--- a/docs/en.html
+++ b/docs/en.html
@@ -3,6 +3,18 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script>
+        // Set the theme before first paint to avoid a flash of the wrong theme.
+        (function () {
+            try {
+                var stored = localStorage.getItem('uptt-theme');
+                var theme = (stored === 'light' || stored === 'dark')
+                    ? stored
+                    : (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+                document.documentElement.setAttribute('data-theme', theme);
+            } catch (e) {}
+        })();
+    </script>
     <title>uPtt — Open Source PTT Messenger</title>
     <meta name="description" content="uPtt is a modern instant messaging desktop app built for PTT (Taiwan's largest BBS), transforming internal mail into a seamless chat experience.">
     <meta name="keywords" content="uPtt, PTT, BBS, instant messaging, mail, open source, messenger, Taiwan">
@@ -29,35 +41,41 @@
             </svg>
             <span>uPtt</span>
         </a>
-        <button class="nav-hamburger" aria-label="Toggle menu" onclick="document.querySelector('.nav-links').classList.toggle('open')">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
-        </button>
-        <ul class="nav-links">
-            <li><a href="#features">Features</a></li>
-            <li><a href="#how-it-works">How It Works</a></li>
-            <li><a href="#security">Security</a></li>
-            <li><a href="#developer">Developer</a></li>
-            <li><a href="https://github.com/uPtt-messenger/uPtt-app" target="_blank" rel="noopener">Source Code</a></li>
-            <li><a href="index.html">繁體中文</a></li>
-            <li><a href="#download" class="btn-nav">Download</a></li>
-        </ul>
+        <div class="nav-right">
+            <ul class="nav-links">
+                <li><a href="#features">Features</a></li>
+                <li><a href="#how-it-works">How It Works</a></li>
+                <li><a href="#security">Security</a></li>
+                <li><a href="#developer">Developer</a></li>
+                <li><a href="https://github.com/uPtt-messenger/uPtt-app" target="_blank" rel="noopener">Source Code</a></li>
+                <li><a href="index.html">繁體中文</a></li>
+                <li><a href="#download" class="btn-nav">Download</a></li>
+            </ul>
+            <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark theme" aria-pressed="false">
+                <svg class="theme-icon theme-icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="theme-icon theme-icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
+            <button class="nav-hamburger" aria-label="Toggle menu" onclick="document.querySelector('.nav-links').classList.toggle('open')">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+            </button>
+        </div>
     </div>
 </nav>
 
 <!-- Hero -->
 <section class="hero">
     <div class="container">
-        <div class="hero-badge" style="background: var(--accent-gold-dim); border-color: rgba(227, 179, 65, 0.2); color: var(--accent-gold);">
-            <span class="dot" style="background: var(--accent-gold);"></span>
-            Closed Beta &middot; <a href="https://github.com/uPtt-messenger/uPtt-app/issues" target="_blank" rel="noopener" style="color: var(--accent-gold); text-decoration: underline;">Report Issues</a>
+        <div class="hero-badge">
+            <span class="dot"></span>
+            Closed Beta &middot; <a href="https://github.com/uPtt-messenger/uPtt-app/issues" target="_blank" rel="noopener">Report Issues</a>
         </div>
         <div class="hero-logo">
             <svg width="240" height="80" viewBox="0 0 240 80" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <rect x="10" y="20" width="40" height="40" rx="8" stroke="#58A6FF" stroke-width="3"/>
                 <path d="M22 35V42C22 45 25 48 30 48C35 48 38 45 38 42V35" stroke="#F0F6FC" stroke-width="3" stroke-linecap="round"/>
                 <circle cx="38" cy="48" r="3" fill="#E3B341"/>
-                <text x="65" y="52" fill="#F0F6FC" font-family="sans-serif" font-weight="bold" font-size="32">uPtt</text>
-                <text x="65" y="68" fill="#8B949E" font-family="sans-serif" font-size="12">Open Source PTT Messenger</text>
+                <text x="65" y="52" fill="#F0F6FC" font-family="ui-monospace, monospace" font-weight="bold" font-size="32">uPtt</text>
+                <text x="65" y="68" fill="#8B949E" font-family="ui-monospace, monospace" font-size="12">Open Source PTT Messenger</text>
             </svg>
         </div>
         <h1 class="hero-tagline">
@@ -78,7 +96,63 @@
             </a>
         </div>
         <div class="hero-preview fade-in">
-            <img src="https://i.meee.com.tw/0RXU0Vt.png" alt="uPtt Login Screen" loading="lazy">
+            <div class="app-window" aria-hidden="true">
+                <div class="app-window-bar">
+                    <span class="win-dot win-dot-red"></span>
+                    <span class="win-dot win-dot-yellow"></span>
+                    <span class="win-dot win-dot-green"></span>
+                    <span class="app-window-title">uPtt</span>
+                </div>
+                <div class="app-window-body">
+                    <aside class="mock-contacts">
+                        <div class="mock-contact active">
+                            <span class="mock-online" data-status="online"></span>
+                            <div class="mock-contact-info">
+                                <span class="mock-contact-name">Cat Mayor</span>
+                                <span class="mock-contact-id">catmayor</span>
+                            </div>
+                        </div>
+                        <div class="mock-contact">
+                            <span class="mock-online" data-status="online"></span>
+                            <div class="mock-contact-info">
+                                <span class="mock-contact-name">Midnight Diner</span>
+                                <span class="mock-contact-id">diner_kai</span>
+                            </div>
+                        </div>
+                        <div class="mock-contact">
+                            <span class="mock-online" data-status="offline"></span>
+                            <div class="mock-contact-info">
+                                <span class="mock-contact-name">Bridge Boss</span>
+                                <span class="mock-contact-id">bcboss</span>
+                            </div>
+                        </div>
+                        <div class="mock-contact">
+                            <span class="mock-online" data-status="unknown"></span>
+                            <div class="mock-contact-info">
+                                <span class="mock-contact-name">CS Nerd</span>
+                                <span class="mock-contact-id">csnerd87</span>
+                            </div>
+                        </div>
+                    </aside>
+                    <section class="mock-chat">
+                        <div class="mock-bubble mock-bubble-in">
+                            <p>You there? My waterballs keep missing me :(</p>
+                            <span class="mock-time">20:58</span>
+                        </div>
+                        <div class="mock-bubble mock-bubble-out">
+                            <p>Query session's reconnecting, one sec</p>
+                            <span class="mock-time">20:59</span>
+                        </div>
+                        <div class="mock-bubble mock-bubble-in">
+                            <p>Got it, thanks for the fix</p>
+                            <span class="mock-time">20:59</span>
+                        </div>
+                        <div class="mock-input">
+                            <span>Type a message…</span><span class="mock-caret"></span>
+                        </div>
+                    </section>
+                </div>
+            </div>
         </div>
     </div>
 </section>
@@ -92,21 +166,21 @@
         <div class="features-grid">
             <div class="feature-card fade-in">
                 <div class="feature-icon green">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#A0C4B4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
                 </div>
                 <h3>Mail to Conversations</h3>
                 <p>Automatically transforms PTT internal mail into intuitive conversations — no more fragmented communication. Supports quote-reply to keep conversation context clear.</p>
             </div>
             <div class="feature-card fade-in">
                 <div class="feature-icon green">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#A0C4B4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
                 </div>
                 <h3>Contact Management</h3>
                 <p>Pin important conversations, drag-and-drop reordering, block or hide contacts. Right-click menu provides multi-level operations.</p>
             </div>
             <div class="feature-card fade-in">
                 <div class="feature-icon gold">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#E3B341" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
                 </div>
                 <h3>Waterball Integration</h3>
                 <p>PTT's instant waterball messages are also captured and displayed. Built-in batch deduplication ensures no duplicates or missed messages.</p>
@@ -122,8 +196,8 @@
         <h2 class="section-title">How It Works</h2>
         <p class="section-desc">uPtt connects directly to PTT's official servers, using internal mail as the message transport layer — no third-party relay needed.</p>
         
-        <div class="alert alert-danger fade-in" style="max-width: 800px; margin: 0 auto 40px; padding: 20px; background: rgba(248, 81, 73, 0.1); border: 1px solid rgba(248, 81, 73, 0.4); border-radius: 8px; color: #ff7b72; text-align: center;">
-            <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor" style="vertical-align: middle; margin-right: 8px;"><path d="M12 7a.75.75 0 0 1 .75.75v4.5a.75.75 0 0 1-1.5 0v-4.5A.75.75 0 0 1 12 7Zm0 9a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path><path d="M1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-9.5A8.5 8.5 0 0 0 3.5 12c0 4.694 3.806 8.5 8.5 8.5s8.5-3.806 8.5-8.5A8.5 8.5 0 0 0 12 2.5Z"></path></svg>
+        <div class="alert alert-danger fade-in">
+            <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor"><path d="M12 7a.75.75 0 0 1 .75.75v4.5a.75.75 0 0 1-1.5 0v-4.5A.75.75 0 0 1 12 7Zm0 9a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path><path d="M1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-9.5A8.5 8.5 0 0 0 3.5 12c0 4.694 3.806 8.5 8.5 8.5s8.5-3.806 8.5-8.5A8.5 8.5 0 0 0 12 2.5Z"></path></svg>
             <strong>Warning:</strong> Please do not manually delete mailbox items while using uPtt to avoid accidental deletions.
         </div>
 
@@ -173,6 +247,55 @@
     </div>
 </section>
 
+<!-- App Showcase -->
+<section class="showcase" id="showcase">
+    <div class="container">
+        <div class="section-label">App Preview</div>
+        <h2 class="section-title">Inside the App</h2>
+        <p class="section-desc">From login to a fully synced dual session, every screen keeps the same terminal-inspired feel.</p>
+        <div class="showcase-grid">
+            <div class="showcase-card fade-in">
+                <div class="app-window" aria-hidden="true">
+                    <div class="app-window-bar">
+                        <span class="win-dot win-dot-red"></span>
+                        <span class="win-dot win-dot-yellow"></span>
+                        <span class="win-dot win-dot-green"></span>
+                        <span class="app-window-title">Login</span>
+                    </div>
+                    <div class="app-window-body app-window-body-solo">
+                        <div class="mock-login">
+                            <label>PTT ID</label>
+                            <div class="mock-field">wonderslab<span class="mock-caret"></span></div>
+                            <label>Password</label>
+                            <div class="mock-field">••••••••</div>
+                            <div class="mock-btn">Log In</div>
+                        </div>
+                    </div>
+                </div>
+                <p class="showcase-caption">Your credentials are only used to connect to PTT — never sent anywhere else.</p>
+            </div>
+            <div class="showcase-card fade-in">
+                <div class="app-window" aria-hidden="true">
+                    <div class="app-window-bar">
+                        <span class="win-dot win-dot-red"></span>
+                        <span class="win-dot win-dot-yellow"></span>
+                        <span class="win-dot win-dot-green"></span>
+                        <span class="app-window-title">Connecting</span>
+                    </div>
+                    <div class="app-window-body app-window-body-solo">
+                        <div class="mock-onboarding">
+                            <p class="mock-step done">✓ Main session logged in</p>
+                            <p class="mock-step active">… Establishing query session<span class="mock-caret"></span></p>
+                            <p class="mock-step">　Syncing message history</p>
+                        </div>
+                    </div>
+                </div>
+                <p class="showcase-caption">Dual-session design: the main session handles messages, the query session checks online status — neither blocks the other.</p>
+            </div>
+        </div>
+    </div>
+</section>
+
 <!-- Security -->
 <section class="security" id="security">
     <div class="container">
@@ -182,7 +305,7 @@
         <div class="security-grid">
             <div class="security-item fade-in">
                 <div class="security-icon">
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#A0C4B4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
                 </div>
                 <div>
                     <h4>Local-only Storage</h4>
@@ -191,7 +314,7 @@
             </div>
             <div class="security-item fade-in">
                 <div class="security-icon">
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#A0C4B4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
                 </div>
                 <div>
                     <h4>Native Protocol</h4>
@@ -200,7 +323,7 @@
             </div>
             <div class="security-item fade-in">
                 <div class="security-icon">
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#A0C4B4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
                 </div>
                 <div>
                     <h4>Automated Leak Prevention</h4>
@@ -209,7 +332,7 @@
             </div>
             <div class="security-item fade-in">
                 <div class="security-icon">
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#A0C4B4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
                 </div>
                 <div>
                     <h4>Code Signing</h4>
@@ -347,6 +470,31 @@
             document.querySelector('.nav-links').classList.remove('open');
         });
     });
+
+    // Theme toggle
+    (function () {
+        const toggle = document.getElementById('theme-toggle');
+        if (!toggle) return;
+
+        function currentTheme() {
+            return document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+        }
+
+        function updateLabel() {
+            const isDark = currentTheme() === 'dark';
+            toggle.setAttribute('aria-pressed', String(isDark));
+            toggle.setAttribute('aria-label', isDark ? 'Switch to light theme' : 'Switch to dark theme');
+        }
+
+        updateLabel();
+
+        toggle.addEventListener('click', () => {
+            const next = currentTheme() === 'dark' ? 'light' : 'dark';
+            document.documentElement.setAttribute('data-theme', next);
+            try { localStorage.setItem('uptt-theme', next); } catch (e) {}
+            updateLabel();
+        });
+    })();
 </script>
 
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,6 +3,18 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script>
+        // Set the theme before first paint to avoid a flash of the wrong theme.
+        (function () {
+            try {
+                var stored = localStorage.getItem('uptt-theme');
+                var theme = (stored === 'light' || stored === 'dark')
+                    ? stored
+                    : (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+                document.documentElement.setAttribute('data-theme', theme);
+            } catch (e) {}
+        })();
+    </script>
     <title>uPtt — 開源 PTT 即時通訊軟體</title>
     <meta name="description" content="uPtt 是一款為批踢踢實業坊量身打造的現代化即時通訊桌面應用程式，將 PTT 站內信轉化為流暢的聊天體驗。">
     <meta name="keywords" content="uPtt, PTT, 批踢踢, 即時通訊, 站內信, BBS, 開源, open source, messenger">
@@ -12,11 +24,6 @@
     <meta property="og:image" content="https://raw.githubusercontent.com/uPtt-messenger/uPtt-app/main/src/uPtt/ui/assets/logo_icon.svg">
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg width='80' height='80' viewBox='0 0 80 80' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='2' y='2' width='76' height='76' rx='18' fill='%23161B22' stroke='%2330363D' stroke-width='2'/%3E%3Crect x='12' y='12' width='56' height='56' rx='12' fill='%230D1117' stroke='%2358A6FF' stroke-width='1.5' stroke-dasharray='2 2'/%3E%3Cpath d='M28 28V42C28 48.6274 33.3726 54 40 54C46.6274 54 52 48.6274 52 42V28' stroke='%23F0F6FC' stroke-width='6' stroke-linecap='round'/%3E%3Cpath d='M52 38V54' stroke='%23F0F6FC' stroke-width='6' stroke-linecap='round'/%3E%3Ccircle cx='28' cy='28' r='5' fill='%2358A6FF'/%3E%3Ccircle cx='52' cy='54' r='5' fill='%23E3B341'/%3E%3C/svg%3E">
     <link rel="stylesheet" href="style.css">
-    <style>
-        :root {
-            --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans TC", "Microsoft JhengHei", Helvetica, Arial, sans-serif;
-        }
-    </style>
 </head>
 <body>
 
@@ -34,35 +41,41 @@
             </svg>
             <span>uPtt</span>
         </a>
-        <button class="nav-hamburger" aria-label="Toggle menu" onclick="document.querySelector('.nav-links').classList.toggle('open')">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
-        </button>
-        <ul class="nav-links">
-            <li><a href="#features">功能</a></li>
-            <li><a href="#how-it-works">運作原理</a></li>
-            <li><a href="#security">安全</a></li>
-            <li><a href="#developer">開發者</a></li>
-            <li><a href="https://github.com/uPtt-messenger/uPtt-app" target="_blank" rel="noopener">原始碼</a></li>
-            <li><a href="en.html">English</a></li>
-            <li><a href="#download" class="btn-nav">下載</a></li>
-        </ul>
+        <div class="nav-right">
+            <ul class="nav-links">
+                <li><a href="#features">功能</a></li>
+                <li><a href="#how-it-works">運作原理</a></li>
+                <li><a href="#security">安全</a></li>
+                <li><a href="#developer">開發者</a></li>
+                <li><a href="https://github.com/uPtt-messenger/uPtt-app" target="_blank" rel="noopener">原始碼</a></li>
+                <li><a href="en.html">English</a></li>
+                <li><a href="#download" class="btn-nav">下載</a></li>
+            </ul>
+            <button class="theme-toggle" id="theme-toggle" type="button" aria-label="切換為深色主題" aria-pressed="false">
+                <svg class="theme-icon theme-icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="theme-icon theme-icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
+            <button class="nav-hamburger" aria-label="Toggle menu" onclick="document.querySelector('.nav-links').classList.toggle('open')">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+            </button>
+        </div>
     </div>
 </nav>
 
 <!-- Hero -->
 <section class="hero">
     <div class="container">
-        <div class="hero-badge" style="background: var(--accent-gold-dim); border-color: rgba(227, 179, 65, 0.2); color: var(--accent-gold);">
-            <span class="dot" style="background: var(--accent-gold);"></span>
-            🚧 封測中 &middot; <a href="https://github.com/uPtt-messenger/uPtt-app/issues" target="_blank" rel="noopener" style="color: var(--accent-gold); text-decoration: underline;">歡迎回報問題</a>
+        <div class="hero-badge">
+            <span class="dot"></span>
+            🚧 封測中 &middot; <a href="https://github.com/uPtt-messenger/uPtt-app/issues" target="_blank" rel="noopener">歡迎回報問題</a>
         </div>
         <div class="hero-logo">
             <svg width="240" height="80" viewBox="0 0 240 80" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <rect x="10" y="20" width="40" height="40" rx="8" stroke="#58A6FF" stroke-width="3"/>
                 <path d="M22 35V42C22 45 25 48 30 48C35 48 38 45 38 42V35" stroke="#F0F6FC" stroke-width="3" stroke-linecap="round"/>
                 <circle cx="38" cy="48" r="3" fill="#E3B341"/>
-                <text x="65" y="52" fill="#F0F6FC" font-family="sans-serif" font-weight="bold" font-size="32">uPtt</text>
-                <text x="65" y="68" fill="#8B949E" font-family="sans-serif" font-size="12">Open Source PTT Messenger</text>
+                <text x="65" y="52" fill="#F0F6FC" font-family="ui-monospace, monospace" font-weight="bold" font-size="32">uPtt</text>
+                <text x="65" y="68" fill="#8B949E" font-family="ui-monospace, monospace" font-size="12">Open Source PTT Messenger</text>
             </svg>
         </div>
         <h1 class="hero-tagline">
@@ -83,7 +96,63 @@
             </a>
         </div>
         <div class="hero-preview fade-in">
-            <img src="https://i.meee.com.tw/0RXU0Vt.png" alt="uPtt 登入畫面" loading="lazy">
+            <div class="app-window" aria-hidden="true">
+                <div class="app-window-bar">
+                    <span class="win-dot win-dot-red"></span>
+                    <span class="win-dot win-dot-yellow"></span>
+                    <span class="win-dot win-dot-green"></span>
+                    <span class="app-window-title">uPtt</span>
+                </div>
+                <div class="app-window-body">
+                    <aside class="mock-contacts">
+                        <div class="mock-contact active">
+                            <span class="mock-online" data-status="online"></span>
+                            <div class="mock-contact-info">
+                                <span class="mock-contact-name">貓村長</span>
+                                <span class="mock-contact-id">catmayor</span>
+                            </div>
+                        </div>
+                        <div class="mock-contact">
+                            <span class="mock-online" data-status="online"></span>
+                            <div class="mock-contact-info">
+                                <span class="mock-contact-name">深夜食堂</span>
+                                <span class="mock-contact-id">diner_kai</span>
+                            </div>
+                        </div>
+                        <div class="mock-contact">
+                            <span class="mock-online" data-status="offline"></span>
+                            <div class="mock-contact-info">
+                                <span class="mock-contact-name">板橋大魔王</span>
+                                <span class="mock-contact-id">bcboss</span>
+                            </div>
+                        </div>
+                        <div class="mock-contact">
+                            <span class="mock-online" data-status="unknown"></span>
+                            <div class="mock-contact-info">
+                                <span class="mock-contact-name">資工肥宅</span>
+                                <span class="mock-contact-id">csnerd87</span>
+                            </div>
+                        </div>
+                    </aside>
+                    <section class="mock-chat">
+                        <div class="mock-bubble mock-bubble-in">
+                            <p>在嗎？水球一直吃不到 QQ</p>
+                            <span class="mock-time">20:58</span>
+                        </div>
+                        <div class="mock-bubble mock-bubble-out">
+                            <p>查線那條在修了，等我一下</p>
+                            <span class="mock-time">20:59</span>
+                        </div>
+                        <div class="mock-bubble mock-bubble-in">
+                            <p>了解，辛苦了 m(_ _)m</p>
+                            <span class="mock-time">20:59</span>
+                        </div>
+                        <div class="mock-input">
+                            <span>輸入訊息…</span><span class="mock-caret"></span>
+                        </div>
+                    </section>
+                </div>
+            </div>
         </div>
     </div>
 </section>
@@ -97,21 +166,21 @@
         <div class="features-grid">
             <div class="feature-card fade-in">
                 <div class="feature-icon green">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#A0C4B4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
                 </div>
                 <h3>站內信變成對話</h3>
                 <p>自動將瑣碎的「站內信」轉換為直覺的「對話」，溝通不再斷斷續續。支援引用回覆，讓對話脈絡一目了然。</p>
             </div>
             <div class="feature-card fade-in">
                 <div class="feature-icon green">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#A0C4B4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
                 </div>
                 <h3>聯絡人管理</h3>
                 <p>釘選重要對話、拖放排序、封鎖或隱藏聯絡人。右鍵選單提供多層級操作，管理對話從未如此簡單。</p>
             </div>
             <div class="feature-card fade-in">
                 <div class="feature-icon gold">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#E3B341" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
                 </div>
                 <h3>水球訊息整合</h3>
                 <p>PTT 的即時水球訊息也能捕獲顯示。內建批次去重機制，確保訊息不重複、不遺漏。</p>
@@ -127,8 +196,8 @@
         <h2 class="section-title">運作原理</h2>
         <p class="section-desc">uPtt 直接連接 PTT 官方伺服器，以站內信作為訊息傳輸層，無需第三方中繼。</p>
         
-        <div class="alert alert-danger fade-in" style="max-width: 800px; margin: 0 auto 40px; padding: 20px; background: rgba(248, 81, 73, 0.1); border: 1px solid rgba(248, 81, 73, 0.4); border-radius: 8px; color: #ff7b72; text-align: center;">
-            <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor" style="vertical-align: middle; margin-right: 8px;"><path d="M12 7a.75.75 0 0 1 .75.75v4.5a.75.75 0 0 1-1.5 0v-4.5A.75.75 0 0 1 12 7Zm0 9a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path><path d="M1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-9.5A8.5 8.5 0 0 0 3.5 12c0 4.694 3.806 8.5 8.5 8.5s8.5-3.806 8.5-8.5A8.5 8.5 0 0 0 12 2.5Z"></path></svg>
+        <div class="alert alert-danger fade-in">
+            <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor"><path d="M12 7a.75.75 0 0 1 .75.75v4.5a.75.75 0 0 1-1.5 0v-4.5A.75.75 0 0 1 12 7Zm0 9a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path><path d="M1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12Zm11-9.5A8.5 8.5 0 0 0 3.5 12c0 4.694 3.806 8.5 8.5 8.5s8.5-3.806 8.5-8.5A8.5 8.5 0 0 0 12 2.5Z"></path></svg>
             <strong>重要警告：</strong> 使用 uPtt 時請勿手動操作刪除信箱內容，以免造成程式誤刪。
         </div>
 
@@ -178,6 +247,55 @@
     </div>
 </section>
 
+<!-- App Showcase -->
+<section class="showcase" id="showcase">
+    <div class="container">
+        <div class="section-label">App Preview</div>
+        <h2 class="section-title">App 畫面一覽</h2>
+        <p class="section-desc">從登入到雙連線就緒，每個畫面都維持一致的終端機質感。</p>
+        <div class="showcase-grid">
+            <div class="showcase-card fade-in">
+                <div class="app-window" aria-hidden="true">
+                    <div class="app-window-bar">
+                        <span class="win-dot win-dot-red"></span>
+                        <span class="win-dot win-dot-yellow"></span>
+                        <span class="win-dot win-dot-green"></span>
+                        <span class="app-window-title">登入</span>
+                    </div>
+                    <div class="app-window-body app-window-body-solo">
+                        <div class="mock-login">
+                            <label>PTT ID</label>
+                            <div class="mock-field">wonderslab<span class="mock-caret"></span></div>
+                            <label>密碼</label>
+                            <div class="mock-field">••••••••</div>
+                            <div class="mock-btn">登入</div>
+                        </div>
+                    </div>
+                </div>
+                <p class="showcase-caption">帳號密碼只用來連線 PTT，不會外傳到任何第三方伺服器。</p>
+            </div>
+            <div class="showcase-card fade-in">
+                <div class="app-window" aria-hidden="true">
+                    <div class="app-window-bar">
+                        <span class="win-dot win-dot-red"></span>
+                        <span class="win-dot win-dot-yellow"></span>
+                        <span class="win-dot win-dot-green"></span>
+                        <span class="app-window-title">連線中</span>
+                    </div>
+                    <div class="app-window-body app-window-body-solo">
+                        <div class="mock-onboarding">
+                            <p class="mock-step done">✓ 主連線登入成功</p>
+                            <p class="mock-step active">… 建立查詢連線<span class="mock-caret"></span></p>
+                            <p class="mock-step">　同步歷史訊息</p>
+                        </div>
+                    </div>
+                </div>
+                <p class="showcase-caption">雙連線架構：主線負責收發訊息，查線專注線上狀態查詢，兩者互不阻塞。</p>
+            </div>
+        </div>
+    </div>
+</section>
+
 <!-- Security -->
 <section class="security" id="security">
     <div class="container">
@@ -187,7 +305,7 @@
         <div class="security-grid">
             <div class="security-item fade-in">
                 <div class="security-icon">
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#A0C4B4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
                 </div>
                 <div>
                     <h4>本地加密存儲</h4>
@@ -196,7 +314,7 @@
             </div>
             <div class="security-item fade-in">
                 <div class="security-icon">
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#A0C4B4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
                 </div>
                 <div>
                     <h4>原生通訊協議</h4>
@@ -205,7 +323,7 @@
             </div>
             <div class="security-item fade-in">
                 <div class="security-icon">
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#A0C4B4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
                 </div>
                 <div>
                     <h4>自動化防洩漏</h4>
@@ -214,7 +332,7 @@
             </div>
             <div class="security-item fade-in">
                 <div class="security-icon">
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#A0C4B4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
                 </div>
                 <div>
                     <h4>程式碼簽章</h4>
@@ -352,6 +470,31 @@
             document.querySelector('.nav-links').classList.remove('open');
         });
     });
+
+    // Theme toggle
+    (function () {
+        const toggle = document.getElementById('theme-toggle');
+        if (!toggle) return;
+
+        function currentTheme() {
+            return document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+        }
+
+        function updateLabel() {
+            const isDark = currentTheme() === 'dark';
+            toggle.setAttribute('aria-pressed', String(isDark));
+            toggle.setAttribute('aria-label', isDark ? '切換為淺色主題' : '切換為深色主題');
+        }
+
+        updateLabel();
+
+        toggle.addEventListener('click', () => {
+            const next = currentTheme() === 'dark' ? 'light' : 'dark';
+            document.documentElement.setAttribute('data-theme', next);
+            try { localStorage.setItem('uptt-theme', next); } catch (e) {}
+            updateLabel();
+        });
+    })();
 </script>
 
 </body>

--- a/docs/style.css
+++ b/docs/style.css
@@ -5,25 +5,86 @@
 }
 
 :root {
-    --bg: #0d1117;
-    --bg-surface: #161b22;
-    --bg-card: #1c2128;
-    --border: #30363d;
-    --border-light: #484f58;
-    --text: #f0f6fc;
-    --text-secondary: #8b949e;
-    --text-muted: #6e7681;
-    --accent: #A0C4B4;
-    --accent-dim: rgba(160, 196, 180, 0.15);
-    --accent-blue: #58A6FF;
-    --accent-blue-dim: rgba(88, 166, 255, 0.15);
-    --accent-gold: #E3B341;
-    --accent-gold-dim: rgba(227, 179, 65, 0.15);
-    --accent-red: #f85149;
-    --font-mono: "SF Mono", "JetBrains Mono", "Cascadia Code", "Fira Code", "Consolas", "Courier New", monospace;
-    --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    /* ---- shared tokens (theme-independent) ---- */
+    --font-mono: ui-monospace, "SF Mono", "Cascadia Code", "JetBrains Mono", "IBM Plex Mono", "Roboto Mono", Consolas, monospace;
     --max-width: 1140px;
     --nav-height: 64px;
+    --radius-sm: 4px;
+    --radius: 8px;
+    --on-accent: #FFFFFF;
+    --accent: #D97757;
+    --accent-hover: #C96442;
+
+    /* ---- design tokens: light (default) ---- */
+    --bg: #ECEEF0;
+    --surface: #F5F3EF;
+    --surface-2: #F0EEE9;
+    --text: #14171B;
+    --text-muted: #5B6169;
+    --border: rgba(20, 23, 27, .12);
+    --border-strong: rgba(20, 23, 27, .24);
+    --nav-bg: rgba(236, 238, 240, .82);
+    --accent-dim: rgba(217, 119, 87, .12);
+    --info: #3B6FA0;
+    --info-dim: rgba(59, 111, 160, .10);
+    --warn: #B8862E;
+    --warn-dim: rgba(184, 134, 46, .12);
+    --success: #3F8F5F;
+    --success-dim: rgba(63, 143, 95, .12);
+    --danger: #C0392B;
+    --danger-dim: rgba(192, 57, 43, .10);
+    --shadow-sm: 0 1px 2px rgba(20, 23, 27, .06);
+    --shadow: 0 8px 24px rgba(20, 23, 27, .10);
+}
+
+/* Follows the OS preference until the user makes an explicit choice */
+@media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+        --bg: #0E1114;
+        --surface: #15191E;
+        --surface-2: #1B2026;
+        --text: #ECEEF0;
+        --text-muted: #8A929B;
+        --border: rgba(236, 238, 240, .10);
+        --border-strong: rgba(236, 238, 240, .20);
+        --nav-bg: rgba(14, 17, 20, .82);
+        --accent-hover: #E08A6B;
+        --accent-dim: rgba(217, 119, 87, .18);
+        --info: #6FA3D1;
+        --info-dim: rgba(111, 163, 209, .14);
+        --warn: #D9A441;
+        --warn-dim: rgba(217, 164, 65, .14);
+        --success: #5FB889;
+        --success-dim: rgba(95, 184, 137, .14);
+        --danger: #E0665A;
+        --danger-dim: rgba(224, 102, 90, .14);
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, .3);
+        --shadow: 0 10px 28px rgba(0, 0, 0, .45);
+    }
+}
+
+/* Explicit user choice — set on <html> before first paint, see the head script */
+:root[data-theme="dark"] {
+    --bg: #0E1114;
+    --surface: #15191E;
+    --surface-2: #1B2026;
+    --text: #ECEEF0;
+    --text-muted: #8A929B;
+    --border: rgba(236, 238, 240, .10);
+    --border-strong: rgba(236, 238, 240, .20);
+    --nav-bg: rgba(14, 17, 20, .82);
+    --accent-hover: #E08A6B;
+    --accent-dim: rgba(217, 119, 87, .18);
+    --info: #6FA3D1;
+    --info-dim: rgba(111, 163, 209, .14);
+    --warn: #D9A441;
+    --warn-dim: rgba(217, 164, 65, .14);
+    --success: #5FB889;
+    --success-dim: rgba(95, 184, 137, .14);
+    --danger: #E0665A;
+    --danger-dim: rgba(224, 102, 90, .14);
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, .3);
+    --shadow: 0 10px 28px rgba(0, 0, 0, .45);
 }
 
 html {
@@ -32,12 +93,13 @@ html {
 }
 
 body {
-    font-family: var(--font-sans);
+    font-family: var(--font-mono);
     background: var(--bg);
     color: var(--text);
     line-height: 1.7;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 /* ===== NAVIGATION ===== */
@@ -47,7 +109,7 @@ nav {
     left: 0;
     right: 0;
     height: var(--nav-height);
-    background: rgba(13, 17, 23, 0.85);
+    background: var(--nav-bg);
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
     border-bottom: 1px solid var(--border);
@@ -64,6 +126,7 @@ nav {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 12px;
 }
 
 .nav-logo {
@@ -86,6 +149,12 @@ nav {
     letter-spacing: -0.02em;
 }
 
+.nav-right {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
 .nav-links {
     display: flex;
     align-items: center;
@@ -94,36 +163,73 @@ nav {
 }
 
 .nav-links a {
-    color: var(--text-secondary);
+    color: var(--text-muted);
     text-decoration: none;
     font-size: 0.9rem;
     padding: 6px 14px;
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
     transition: color 0.2s, background 0.2s;
 }
 
 .nav-links a:hover {
     color: var(--text);
-    background: rgba(255, 255, 255, 0.06);
+    background: var(--surface-2);
 }
 
 .nav-links .btn-nav {
     background: var(--accent);
-    color: var(--bg);
+    color: var(--on-accent);
     font-weight: 600;
     padding: 8px 18px;
 }
 
 .nav-links .btn-nav:hover {
-    background: #b5d4c7;
-    color: var(--bg);
+    background: var(--accent-hover);
+    color: var(--on-accent);
+}
+
+.theme-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: color 0.2s, border-color 0.2s;
+    flex-shrink: 0;
+}
+
+.theme-toggle:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+}
+
+.theme-icon {
+    width: 18px;
+    height: 18px;
+}
+
+.theme-icon-moon {
+    display: none;
+}
+
+:root[data-theme="dark"] .theme-icon-sun {
+    display: none;
+}
+
+:root[data-theme="dark"] .theme-icon-moon {
+    display: block;
 }
 
 .nav-hamburger {
     display: none;
     background: none;
     border: none;
-    color: var(--text-secondary);
+    color: var(--text-muted);
     cursor: pointer;
     padding: 8px;
 }
@@ -163,7 +269,7 @@ section {
 
 .section-desc {
     font-size: 1.1rem;
-    color: var(--text-secondary);
+    color: var(--text-muted);
     max-width: 640px;
     line-height: 1.8;
 }
@@ -185,7 +291,7 @@ section {
     transform: translateX(-50%);
     width: 800px;
     height: 800px;
-    background: radial-gradient(circle, rgba(160, 196, 180, 0.06) 0%, transparent 70%);
+    background: radial-gradient(circle, var(--accent-dim) 0%, transparent 70%);
     pointer-events: none;
 }
 
@@ -198,6 +304,11 @@ section {
     height: auto;
 }
 
+/* Wordmark glyph + text were hardcoded #F0F6FC (invisible on light); drive from theme tokens. CSS fill/stroke beats the SVG presentation attribute. */
+.hero-logo path { stroke: var(--text); }
+.hero-logo text:first-of-type { fill: var(--text); }
+.hero-logo text:last-of-type { fill: var(--text-muted); }
+
 .hero-tagline {
     font-family: var(--font-mono);
     font-size: clamp(1.5rem, 4vw, 2.75rem);
@@ -208,7 +319,7 @@ section {
 }
 
 .hero-tagline .highlight {
-    background: linear-gradient(135deg, var(--accent), var(--accent-blue));
+    background: linear-gradient(135deg, var(--accent), var(--accent-hover));
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
@@ -216,7 +327,7 @@ section {
 
 .hero-subtitle {
     font-size: 1.2rem;
-    color: var(--text-secondary);
+    color: var(--text-muted);
     max-width: 580px;
     margin: 0 auto 40px;
     line-height: 1.8;
@@ -235,7 +346,7 @@ section {
     align-items: center;
     gap: 10px;
     padding: 14px 28px;
-    border-radius: 10px;
+    border-radius: var(--radius);
     text-decoration: none;
     font-weight: 600;
     font-size: 1rem;
@@ -251,25 +362,25 @@ section {
 
 .btn-primary {
     background: var(--accent);
-    color: var(--bg);
+    color: var(--on-accent);
 }
 
 .btn-primary:hover {
-    background: #b5d4c7;
-    transform: translateY(-2px);
-    box-shadow: 0 8px 24px rgba(160, 196, 180, 0.2);
+    background: var(--accent-hover);
+    transform: translateY(-1px);
+    box-shadow: 0 6px 18px rgba(217, 119, 87, .28);
 }
 
 .btn-secondary {
-    background: var(--bg-card);
+    background: var(--surface-2);
     color: var(--text);
     border: 1px solid var(--border);
 }
 
 .btn-secondary:hover {
-    border-color: var(--border-light);
-    transform: translateY(-2px);
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+    border-color: var(--border-strong);
+    transform: translateY(-1px);
+    box-shadow: var(--shadow-sm);
 }
 
 .hero-badge {
@@ -277,19 +388,24 @@ section {
     align-items: center;
     gap: 8px;
     padding: 6px 16px;
-    background: var(--accent-dim);
-    border: 1px solid rgba(160, 196, 180, 0.2);
+    background: var(--warn-dim);
+    border: 1px solid var(--warn-dim);
     border-radius: 100px;
     font-size: 0.85rem;
-    color: var(--accent);
+    color: var(--warn);
     font-family: var(--font-mono);
     margin-bottom: 24px;
+}
+
+.hero-badge a {
+    color: inherit;
+    text-decoration: underline;
 }
 
 .hero-badge .dot {
     width: 6px;
     height: 6px;
-    background: var(--accent);
+    background: var(--warn);
     border-radius: 50%;
     animation: pulse-dot 2s infinite;
 }
@@ -302,21 +418,226 @@ section {
 .hero-preview {
     max-width: 560px;
     margin: 0 auto;
-    border-radius: 16px;
-    overflow: hidden;
-    border: 1px solid var(--border);
-    box-shadow: 0 24px 48px rgba(0, 0, 0, 0.4);
 }
 
-.hero-preview img {
-    width: 100%;
-    height: auto;
-    display: block;
+/* ===== APP WINDOW MOCKUP =====
+   Hand-built app chrome shared by the hero preview and the App Showcase
+   section below. Colors are all CSS vars so it re-themes with the page. */
+.app-window {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow: hidden;
+    box-shadow: var(--shadow);
+    text-align: left;
 }
+
+.app-window-bar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+}
+
+.win-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    display: inline-block;
+}
+
+.win-dot-red { background: var(--danger); }
+.win-dot-yellow { background: var(--warn); }
+.win-dot-green { background: var(--success); }
+
+.app-window-title {
+    margin-left: 6px;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+}
+
+.app-window-body {
+    display: grid;
+    grid-template-columns: 140px 1fr;
+    min-height: 320px;
+}
+
+.app-window-body-solo {
+    display: block;
+    padding: 28px 24px;
+    min-height: 200px;
+}
+
+.mock-contacts {
+    display: flex;
+    flex-direction: column;
+    border-right: 1px solid var(--border);
+    background: var(--surface);
+    padding: 10px 0;
+}
+
+.mock-contact {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+}
+
+.mock-contact.active {
+    background: var(--accent-dim);
+    border-left: 2px solid var(--accent);
+    padding-left: 12px;
+}
+
+.mock-online {
+    width: 8px;
+    height: 8px;
+    min-width: 8px;
+    border-radius: 50%;
+}
+
+.mock-online[data-status="online"] { background: var(--success); }
+.mock-online[data-status="offline"] { background: var(--text-muted); opacity: .5; }
+.mock-online[data-status="unknown"] { background: transparent; border: 1px solid var(--text-muted); }
+
+.mock-contact-info {
+    display: flex;
+    flex-direction: column;
+    line-height: 1.3;
+    overflow: hidden;
+}
+
+.mock-contact-name {
+    font-size: 0.78rem;
+    color: var(--text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.mock-contact-id {
+    font-size: 0.68rem;
+    color: var(--text-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.mock-chat {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 18px;
+    background: var(--surface-2);
+}
+
+.mock-bubble {
+    max-width: 78%;
+    padding: 8px 12px;
+    border-radius: var(--radius-sm);
+    font-size: 0.82rem;
+}
+
+.mock-bubble p {
+    margin: 0;
+    line-height: 1.5;
+}
+
+.mock-bubble-in {
+    align-self: flex-start;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    color: var(--text);
+}
+
+.mock-bubble-out {
+    align-self: flex-end;
+    background: var(--accent-dim);
+    border: 1px solid var(--accent);
+    color: var(--text);
+}
+
+.mock-time {
+    display: block;
+    margin-top: 4px;
+    font-size: 0.65rem;
+    color: var(--text-muted);
+}
+
+.mock-input {
+    margin-top: auto;
+    display: flex;
+    align-items: center;
+    padding: 10px 12px;
+    border: 1px dashed var(--border);
+    border-radius: var(--radius-sm);
+    font-size: 0.82rem;
+    color: var(--text-muted);
+    background: var(--surface);
+}
+
+.mock-caret {
+    display: inline-block;
+    width: 7px;
+    height: 1em;
+    margin-left: 2px;
+    background: var(--accent);
+    animation: blink 1s steps(1) infinite;
+    vertical-align: text-bottom;
+}
+
+@keyframes blink {
+    50% { opacity: 0; }
+}
+
+.mock-login label {
+    display: block;
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin: 14px 0 6px;
+}
+
+.mock-login label:first-child {
+    margin-top: 0;
+}
+
+.mock-field {
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 8px 10px;
+    font-size: 0.85rem;
+    background: var(--surface);
+    color: var(--text);
+}
+
+.mock-btn {
+    margin-top: 20px;
+    background: var(--accent);
+    color: var(--on-accent);
+    text-align: center;
+    padding: 9px;
+    border-radius: var(--radius-sm);
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+.mock-onboarding .mock-step {
+    font-size: 0.85rem;
+    margin: 12px 0;
+    color: var(--text-muted);
+}
+
+.mock-onboarding .mock-step.done { color: var(--success); }
+.mock-onboarding .mock-step.active { color: var(--text); }
 
 /* ===== FEATURES ===== */
 .features {
-    background: var(--bg-surface);
+    background: var(--surface);
     border-top: 1px solid var(--border);
     border-bottom: 1px solid var(--border);
 }
@@ -329,32 +650,35 @@ section {
 }
 
 .feature-card {
-    background: var(--bg-card);
+    background: var(--surface-2);
     border: 1px solid var(--border);
-    border-radius: 12px;
+    border-radius: var(--radius);
     padding: 32px 28px;
     transition: border-color 0.2s, transform 0.2s;
 }
 
 .feature-card:hover {
-    border-color: var(--border-light);
+    border-color: var(--border-strong);
     transform: translateY(-4px);
 }
 
 .feature-icon {
     width: 48px;
     height: 48px;
-    border-radius: 12px;
+    border-radius: 6px;
     display: flex;
     align-items: center;
     justify-content: center;
     margin-bottom: 20px;
-    font-size: 1.5rem;
 }
 
-.feature-icon.green { background: var(--accent-dim); }
-.feature-icon.blue { background: var(--accent-blue-dim); }
-.feature-icon.gold { background: var(--accent-gold-dim); }
+.feature-icon svg {
+    width: 24px;
+    height: 24px;
+}
+
+.feature-icon.green { background: var(--accent-dim); color: var(--accent); }
+.feature-icon.gold { background: var(--warn-dim); color: var(--warn); }
 
 .feature-card h3 {
     font-family: var(--font-mono);
@@ -364,14 +688,33 @@ section {
 }
 
 .feature-card p {
-    color: var(--text-secondary);
+    color: var(--text-muted);
     font-size: 0.95rem;
     line-height: 1.7;
 }
 
 /* ===== HOW IT WORKS ===== */
 .how-it-works .section-desc {
-    margin-bottom: 56px;
+    margin-bottom: 40px;
+}
+
+.alert {
+    max-width: 800px;
+    margin: 0 auto 40px;
+    padding: 20px;
+    border-radius: var(--radius);
+    text-align: center;
+}
+
+.alert svg {
+    vertical-align: middle;
+    margin-right: 8px;
+}
+
+.alert-danger {
+    background: var(--danger-dim);
+    border: 1px solid var(--danger);
+    color: var(--danger);
 }
 
 .flow-diagram {
@@ -395,7 +738,7 @@ section {
     right: -12px;
     width: 24px;
     height: 2px;
-    background: var(--border-light);
+    background: var(--border-strong);
 }
 
 .flow-step:last-child::after {
@@ -425,14 +768,14 @@ section {
 }
 
 .flow-step p {
-    color: var(--text-secondary);
+    color: var(--text-muted);
     font-size: 0.9rem;
     line-height: 1.7;
 }
 
 /* ===== MESSAGE TYPES ===== */
 .msg-types {
-    background: var(--bg-surface);
+    background: var(--surface);
     border-top: 1px solid var(--border);
     border-bottom: 1px solid var(--border);
 }
@@ -445,9 +788,9 @@ section {
 }
 
 .msg-card {
-    background: var(--bg-card);
+    background: var(--surface-2);
     border: 1px solid var(--border);
-    border-radius: 12px;
+    border-radius: var(--radius);
     padding: 28px 24px;
     position: relative;
     overflow: hidden;
@@ -463,8 +806,8 @@ section {
 }
 
 .msg-card.type-uptt::before { background: var(--accent); }
-.msg-card.type-mail::before { background: var(--accent-blue); }
-.msg-card.type-waterball::before { background: var(--accent-gold); }
+.msg-card.type-mail::before { background: var(--info); }
+.msg-card.type-waterball::before { background: var(--warn); }
 
 .msg-card .msg-tag {
     font-family: var(--font-mono);
@@ -477,8 +820,8 @@ section {
 }
 
 .type-uptt .msg-tag { background: var(--accent-dim); color: var(--accent); }
-.type-mail .msg-tag { background: var(--accent-blue-dim); color: var(--accent-blue); }
-.type-waterball .msg-tag { background: var(--accent-gold-dim); color: var(--accent-gold); }
+.type-mail .msg-tag { background: var(--info-dim); color: var(--info); }
+.type-waterball .msg-tag { background: var(--warn-dim); color: var(--warn); }
 
 .msg-card h3 {
     font-family: var(--font-mono);
@@ -487,9 +830,28 @@ section {
 }
 
 .msg-card p {
-    color: var(--text-secondary);
+    color: var(--text-muted);
     font-size: 0.9rem;
     line-height: 1.7;
+}
+
+/* ===== APP SHOWCASE ===== */
+.showcase-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 24px;
+    margin-top: 48px;
+}
+
+.showcase-card {
+    display: flex;
+    flex-direction: column;
+}
+
+.showcase-caption {
+    margin-top: 14px;
+    font-size: 0.85rem;
+    color: var(--text-muted);
 }
 
 /* ===== SECURITY ===== */
@@ -505,21 +867,26 @@ section {
     gap: 16px;
     align-items: flex-start;
     padding: 24px;
-    background: var(--bg-card);
+    background: var(--surface-2);
     border: 1px solid var(--border);
-    border-radius: 12px;
+    border-radius: var(--radius);
 }
 
 .security-icon {
     width: 40px;
     height: 40px;
     min-width: 40px;
-    border-radius: 10px;
+    border-radius: 6px;
     background: var(--accent-dim);
+    color: var(--accent);
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 1.2rem;
+}
+
+.security-icon svg {
+    width: 20px;
+    height: 20px;
 }
 
 .security-item h4 {
@@ -529,7 +896,7 @@ section {
 }
 
 .security-item p {
-    color: var(--text-secondary);
+    color: var(--text-muted);
     font-size: 0.9rem;
     line-height: 1.6;
 }
@@ -550,9 +917,9 @@ section {
 }
 
 .download-card {
-    background: var(--bg-card);
+    background: var(--surface-2);
     border: 1px solid var(--border);
-    border-radius: 16px;
+    border-radius: var(--radius);
     padding: 40px 32px;
     text-align: center;
     text-decoration: none;
@@ -570,7 +937,7 @@ section {
     width: 48px;
     height: 48px;
     margin-bottom: 20px;
-    color: var(--text-secondary);
+    color: var(--text-muted);
 }
 
 .download-card h3 {
@@ -580,13 +947,13 @@ section {
 }
 
 .download-card p {
-    color: var(--text-secondary);
+    color: var(--text-muted);
     font-size: 0.9rem;
 }
 
 /* ===== DEVELOPER ===== */
 .developer {
-    background: var(--bg-surface);
+    background: var(--surface);
     border-top: 1px solid var(--border);
     border-bottom: 1px solid var(--border);
 }
@@ -594,7 +961,7 @@ section {
 .code-block {
     background: var(--bg);
     border: 1px solid var(--border);
-    border-radius: 12px;
+    border-radius: var(--radius);
     padding: 28px 32px;
     margin-top: 32px;
     overflow-x: auto;
@@ -605,11 +972,12 @@ section {
     font-family: var(--font-mono);
     font-size: 0.9rem;
     line-height: 2;
-    color: var(--text-secondary);
+    color: var(--text-muted);
 }
 
 .code-block .comment {
     color: var(--text-muted);
+    opacity: .7;
 }
 
 .code-block .cmd {
@@ -617,7 +985,7 @@ section {
 }
 
 .code-block .prompt {
-    color: var(--accent-blue);
+    color: var(--info);
     user-select: none;
 }
 
@@ -645,7 +1013,7 @@ section {
 }
 
 .shortcuts-table th {
-    color: var(--text-secondary);
+    color: var(--text-muted);
     font-family: var(--font-mono);
     font-size: 0.8rem;
     text-transform: uppercase;
@@ -654,16 +1022,16 @@ section {
 
 .shortcuts-table kbd {
     font-family: var(--font-mono);
-    background: var(--bg-card);
+    background: var(--surface-2);
     border: 1px solid var(--border);
     padding: 2px 8px;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     font-size: 0.85rem;
-    color: var(--accent-blue);
+    color: var(--info);
 }
 
 .shortcuts-table td:last-child {
-    color: var(--text-secondary);
+    color: var(--text-muted);
 }
 
 /* ===== FOOTER ===== */
@@ -687,7 +1055,7 @@ footer {
 }
 
 .footer-links a {
-    color: var(--text-secondary);
+    color: var(--text-muted);
     text-decoration: none;
     font-size: 0.9rem;
     transition: color 0.2s;
@@ -704,7 +1072,7 @@ footer {
 }
 
 .footer-copy a {
-    color: var(--text-secondary);
+    color: var(--text-muted);
     text-decoration: none;
 }
 
@@ -716,7 +1084,8 @@ footer {
 @media (max-width: 900px) {
     .features-grid,
     .msg-grid,
-    .flow-diagram {
+    .flow-diagram,
+    .showcase-grid {
         grid-template-columns: 1fr;
     }
 
@@ -746,7 +1115,7 @@ footer {
         top: var(--nav-height);
         left: 0;
         right: 0;
-        background: var(--bg-surface);
+        background: var(--surface);
         border-bottom: 1px solid var(--border);
         padding: 16px 24px;
         gap: 4px;
@@ -780,6 +1149,17 @@ footer {
         max-width: 300px;
         justify-content: center;
     }
+
+    .app-window-body {
+        grid-template-columns: 1fr;
+    }
+
+    .mock-contacts {
+        border-right: none;
+        border-bottom: 1px solid var(--border);
+        max-height: 160px;
+        overflow-y: auto;
+    }
 }
 
 /* ===== ANIMATIONS ===== */
@@ -800,5 +1180,10 @@ footer {
     .fade-in {
         opacity: 1;
         transform: none;
+    }
+
+    .mock-caret {
+        animation: none;
+        opacity: 1;
     }
 }


### PR DESCRIPTION
## What

Redesigns the uPtt marketing site (`docs/`) in the 2026 design language from the app UI design canvas.

- **Light/dark themes** — toggle in the nav; follows `prefers-color-scheme` by default, remembers choice in `localStorage`, FOUC-safe head script
- **New visual language** — cool-neutral light base (`#ECEEF0`) / dark (`#0E1114`), coral accent `#D97757` (replaces green), full monospace type, BBS texture + blinking caret
- **Hand-built app mockups** — chat-window hero (no more external PNG) + an "app screens" showcase (login / onboarding), all driven by the same CSS variables so they re-color with the theme
- **Bilingual** — `index.html` and `en.html` kept structurally identical (same section class/id order)
- `style.css` reworked into a two-theme CSS-variable token system; no new dependencies, no external CDN

## Testing

- Theme toggle: default follows system, choice persists across reload, no white flash on load
- Mockups re-color correctly in both themes; RWD verified at 375px (no horizontal overflow, menu collapses, two-column mockup stacks)
- `index.html` vs `en.html` section structure diff-identical
- Verified via chrome-devtools (dynamic) + independent static audit against 7 acceptance criteria

Base is `beta` (project's feature-branch base); diff is the redesign only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPsbpNXX7GCP5AtwStTgMv