### PR TITLE
fix(ci): 還原 Windows build 的 ChineseTraditional.isl 下載步驟

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -521,8 +521,16 @@ jobs:
             Write-Host "Smoke test passed (binary was still running after 10s)"
           }
 
-      # ChineseTraditional.isl ships with Inno Setup as an official language since 6.5.0
-      # (runner has 6.7.1), so no download needed. The old Unofficial/ URL now 404s.
+      - name: Download Inno Setup Chinese Traditional language file
+        shell: pwsh
+        run: |
+          $langDir = "C:\Program Files (x86)\Inno Setup 6\Languages"
+          # ChineseTraditional.isl is not bundled with the shipped Inno Setup on the
+          # runner; it was promoted out of Unofficial/ in source, so fetch the official
+          # path. installer.iss includes it via compiler:Languages\ChineseTraditional.isl.
+          $url = "https://raw.githubusercontent.com/jrsoftware/issrc/main/Files/Languages/ChineseTraditional.isl"
+          Invoke-WebRequest -Uri $url -OutFile "$langDir\ChineseTraditional.isl"
+
       - name: Build installer with Inno Setup
         shell: pwsh
         run: |


### PR DESCRIPTION
## 問題

`beta` 上 Windows build 失敗(merge #27 後、及 #25 當時皆然):

```
Error on line 35 in installer.iss: Couldn't open include file
"C:\Program Files (x86)\Inno Setup 6\Languages\ChineseTraditional.isl":
The system cannot find the file specified.
Compile aborted.
```

`scripts/installer.iss:35` 以 `compiler:Languages\ChineseTraditional.isl` include 繁中語言檔,但 runner 上的 Inno Setup 6.7.1 在該路徑並未附此檔。

## 根因

#25(`fix/audit-findings`)的 build.yml 假設「Inno Setup 6.5+ 已內建 ChineseTraditional.isl,免下載」而移除了下載步驟。此假設在 runner 上不成立 —— 該檔未隨已安裝的 Inno Setup 出現在 `Languages\`,打包遂於 include 階段 abort。#27 合併時採用了 beta 版 build.yml,因而繼承此問題。

## 修法

還原下載步驟:自 jrsoftware/issrc 官方路徑(該檔已由 `Unofficial/` 升級為官方語言,raw 回 200)抓到 installer.iss 期望的 `Languages\ChineseTraditional.isl`。

- 已驗證 `https://raw.githubusercontent.com/jrsoftware/issrc/main/Files/Languages/ChineseTraditional.isl` → `200`
- `Unofficial/` 舊路徑 → `404`(佐證已升級)
- build.yml YAML 解析通過

> 註:同一 run 的 `publish-pypi` 失敗屬 PyPI trusted-publisher 設定問題,與本修正無關,不在此處理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rpx2T6Nnwra7gLDg7toKQF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rpx2T6Nnwra7gLDg7toKQF)_