### PR TITLE
feat: 送訊息失敗可重新傳送 + 失敗改非阻斷狀態列提示 (artboard 28)

### DIFF
--- a/src/uPtt/db.py
+++ b/src/uPtt/db.py
@@ -478,6 +478,19 @@ class DatabaseManager:
             logger.error(f"清理殘留 pending 訊息失敗：{e}")
             return 0
 
+    def get_message_content(self, account_id: str, message_id: int) -> Optional[str]:
+        """回傳指定訊息 row 存的（編碼後）content，供重送使用。查無回傳 None。"""
+        try:
+            with self._get_connection() as conn:
+                row = conn.execute(
+                    "SELECT content FROM messages WHERE account_id = ? AND id = ?",
+                    (account_id.lower(), message_id)
+                ).fetchone()
+                return row['content'] if row else None
+        except sqlite3.Error as e:
+            logger.error(f"取得訊息內容失敗 (id={message_id})：{e}")
+            return None
+
     def get_messages(self, account_id: str, session_id: str, limit: Optional[int] = 50) -> List[Dict[str, Any]]:
         """取得特定帳號與特定對象的歷史訊息。limit=None 時回傳全部（不截斷）。"""
         try:

--- a/src/uPtt/ui/screens.py
+++ b/src/uPtt/ui/screens.py
@@ -1966,6 +1966,7 @@ class MainWindow(QMainWindow):
                                     message_id=msg.get('msg_id'))
                 widget.reply_requested.connect(self.set_reply_to)
                 widget.delete_requested.connect(self.handle_delete_message)
+                widget.retry_requested.connect(self.handle_retry_message)
             self.messages_layout.addWidget(widget)
         
         # 標記強制捲到底部，待 rangeChanged 信號觸發時執行
@@ -2020,6 +2021,41 @@ class MainWindow(QMainWindow):
             if widget and widget.ptt_id == session_id:
                 widget.set_last_msg_time(_format_contact_time(row.get('last_message_time', '') if row else ''))
                 break
+
+    def handle_retry_message(self, msg_id: int):
+        """重新傳送發送失敗的自訊息：狀態翻回 pending、重用同 msg_id re-enqueue
+        （走既有 _do_send，不動 worker）。"""
+        if not msg_id or msg_id <= 0:
+            return
+        current_acc = self.ptt_service.ptt_id
+        content = self.db.get_message_content(current_acc, msg_id)
+        if content is None:
+            return
+
+        # 從快取找到訊息所在會話與時間戳（失敗泡泡必在已載入的對話中）
+        receiver_id = None
+        timestamp = None
+        target_msg = None
+        for chat_id, history in self.chat_histories.items():
+            for msg in history:
+                if msg.get('msg_id') == msg_id:
+                    receiver_id, timestamp, target_msg = chat_id, msg.get('timestamp'), msg
+                    break
+            if receiver_id is not None:
+                break
+        if receiver_id is None:
+            return
+
+        # 狀態翻回 pending（DB + 快取 + 畫面）
+        self.db.update_message_status(msg_id, 'pending')
+        if target_msg is not None:
+            target_msg['send_status'] = 'pending'
+        if self.current_chat_id == receiver_id:
+            self.refresh_chat_display()
+
+        # 重用同 msg_id re-enqueue（thread-safe 佇列 + 喚醒 worker drain）
+        self.worker.enqueue_send(receiver_id, content, timestamp, msg_id)
+        self.send_requested.emit(receiver_id, content, timestamp, msg_id)
 
     def _get_contact_display_id(self, ptt_id_lower: str) -> str:
         for i in range(self.contact_list.count()):
@@ -2211,7 +2247,14 @@ class MainWindow(QMainWindow):
         if updated_chat == self.current_chat_id:
             self.refresh_chat_display()
         if not success:
-            QMessageBox.warning(self, "發送失敗", f"無法發送訊息: {error_msg}")
+            # 非阻斷提示：狀態列閃現，不再彈 QMessageBox 卡住操作。
+            # 使用者可在失敗泡泡右鍵「重新傳送」。
+            self._flash_status(f"發送失敗：{error_msg}（可於訊息右鍵重新傳送）")
+
+    def _flash_status(self, message: str, ms: int = 5000):
+        """在底部狀態列左側暫時顯示提示，ms 後還原為對話/未讀計數。"""
+        self._status_left.setText(message)
+        QTimer.singleShot(ms, self._update_status_bar)
 
     def on_tray_activated(self, reason):
         if reason == QSystemTrayIcon.Trigger:

--- a/src/uPtt/ui/widgets.py
+++ b/src/uPtt/ui/widgets.py
@@ -46,6 +46,7 @@ class ChatBubble(QWidget):
     """
     reply_requested = Signal(str, bool)  # (message_text, is_me)
     delete_requested = Signal(int)  # message_id
+    retry_requested = Signal(int)  # message_id（重新傳送發送失敗的自訊息）
 
     def __init__(self, text: str, time_str: str, is_me: bool = False,
                  reply_info: Optional[dict] = None, send_status: Optional[str] = None,
@@ -189,6 +190,11 @@ class ChatBubble(QWidget):
 
         if self.message_id is not None:
             menu.addSeparator()
+            # 自訊息且發送失敗 → 提供「重新傳送」
+            if self.is_me and self._send_status == 'failed':
+                retry_action = QAction("重新傳送", self)
+                retry_action.triggered.connect(lambda: self.retry_requested.emit(self.message_id))
+                menu.addAction(retry_action)
             delete_action = QAction("刪除（僅本機）", self)
             delete_action.triggered.connect(lambda: self.delete_requested.emit(self.message_id))
             menu.addAction(delete_action)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -586,3 +586,18 @@ def test_search_messages_escapes_wildcards(db_manager):
     # 經典注入字串應查無資料且不刪表
     assert db_manager.search_messages(acc, "'; DROP TABLE messages;--") == []
     assert db_manager.search_messages(acc, "50%")  # messages 表仍在
+
+
+def test_get_message_content_returns_stored_content(db_manager):
+    acc, sid = "alice", "bob"
+    db_manager.upsert_account(acc, acc)
+    db_manager.upsert_session(acc, sid)
+    mid = db_manager.save_message(acc, sid, acc, sid, "[re:@bob|x]\n編碼內容", datetime.now(), True)
+    assert db_manager.get_message_content(acc, mid) == "[re:@bob|x]\n編碼內容"
+    # 大小寫不敏感的 account key
+    assert db_manager.get_message_content("ALICE", mid) == "[re:@bob|x]\n編碼內容"
+
+
+def test_get_message_content_unknown_returns_none(db_manager):
+    db_manager.upsert_account("alice", "alice")
+    assert db_manager.get_message_content("alice", 999999) is None

--- a/tests/test_ui_screens.py
+++ b/tests/test_ui_screens.py
@@ -434,7 +434,9 @@ def test_send_result_updates_status_when_user_switched_chat(mock_qthread, mock_w
 
         # The pending bubble in A must now be 'failed', not lost
         assert window.chat_histories['contacta'][-1]['send_status'] == 'failed'
-        mock_msgbox.warning.assert_called_once()
+        # 失敗改為非阻斷狀態列提示（不再彈 QMessageBox）
+        mock_msgbox.warning.assert_not_called()
+        assert "發送失敗" in window._status_left.text()
 
 
 @patch('src.uPtt.ui.screens.VersionCheckWorker')
@@ -932,3 +934,46 @@ def test_load_sessions_shows_mute_icon_for_muted_session(mock_qthread, mock_work
         widget = window.contact_list.itemWidget(window.contact_list.item(0))
         assert widget._is_muted is True
         assert widget.mute_icon_label.isVisible() is True
+
+
+@patch('src.uPtt.ui.screens.VersionCheckWorker')
+@patch('src.uPtt.ui.screens.QueryWorker')
+@patch('src.uPtt.ui.screens.PTTWorker')
+@patch('src.uPtt.ui.screens.QThread')
+def test_handle_retry_message_reenqueues_same_id(mock_qthread, mock_worker, mock_query_worker, mock_ver_worker, qtbot, ptt_service_mock, ptt_query_service_mock, db_mock):
+    """重新傳送:狀態 failed→pending,以同 msg_id re-enqueue,內容取自 get_message_content。"""
+    with patch('os.path.exists', return_value=True):
+        window = MainWindow(ptt_service_mock, ptt_query_service_mock, db_mock)
+        qtbot.addWidget(window)
+        window.add_or_select_contact("ContactA")
+        window.message_edit.setText("hi")
+        with patch.object(window, 'send_requested'):
+            window.handle_send()
+        msg_id = window.chat_histories['contacta'][-1]['msg_id']
+
+        # 送失敗 → failed
+        window.on_send_result(msg_id, False, "boom")
+        assert window.chat_histories['contacta'][-1]['send_status'] == 'failed'
+
+        # 重試
+        db_mock.get_message_content.return_value = "encoded-content"
+        with patch.object(window, 'send_requested'):
+            window.handle_retry_message(msg_id)
+
+        assert window.chat_histories['contacta'][-1]['send_status'] == 'pending'
+        db_mock.update_message_status.assert_any_call(msg_id, 'pending')
+        db_mock.get_message_content.assert_called_with("MyID", msg_id)
+        window.worker.enqueue_send.assert_called_with('contacta', 'encoded-content', ANY, msg_id)
+
+
+@patch('src.uPtt.ui.screens.VersionCheckWorker')
+@patch('src.uPtt.ui.screens.QueryWorker')
+@patch('src.uPtt.ui.screens.PTTWorker')
+@patch('src.uPtt.ui.screens.QThread')
+def test_handle_retry_message_noop_when_content_missing(mock_qthread, mock_worker, mock_query_worker, mock_ver_worker, qtbot, ptt_service_mock, ptt_query_service_mock, db_mock):
+    with patch('os.path.exists', return_value=True):
+        window = MainWindow(ptt_service_mock, ptt_query_service_mock, db_mock)
+        qtbot.addWidget(window)
+        db_mock.get_message_content.return_value = None
+        window.handle_retry_message(123)
+        window.worker.enqueue_send.assert_not_called()

--- a/tests/test_ui_widgets.py
+++ b/tests/test_ui_widgets.py
@@ -132,3 +132,38 @@ def test_contact_item_get_data_includes_is_muted(qtbot):
     item.set_muted(True)
     data = item.get_data()
     assert data['is_muted'] is True
+
+
+def test_chat_bubble_retry_action_shown_when_failed(qtbot):
+    bubble = ChatBubble("msg", "10:00", is_me=True, send_status='failed', message_id=7)
+    qtbot.addWidget(bubble)
+    menu = bubble._build_context_menu()
+    labels = [a.text() for a in menu.actions()]
+    assert any("重新傳送" in t for t in labels)
+
+
+def test_chat_bubble_retry_action_absent_when_not_failed(qtbot):
+    for status in ('sent', 'pending'):
+        bubble = ChatBubble("msg", "10:00", is_me=True, send_status=status, message_id=7)
+        qtbot.addWidget(bubble)
+        labels = [a.text() for a in bubble._build_context_menu().actions()]
+        assert not any("重新傳送" in t for t in labels), status
+
+
+def test_chat_bubble_retry_absent_for_received(qtbot):
+    bubble = ChatBubble("msg", "10:00", is_me=False, send_status='failed', message_id=7)
+    qtbot.addWidget(bubble)
+    labels = [a.text() for a in bubble._build_context_menu().actions()]
+    assert not any("重新傳送" in t for t in labels)
+
+
+def test_chat_bubble_retry_emits_message_id(qtbot):
+    bubble = ChatBubble("msg", "10:00", is_me=True, send_status='failed', message_id=42)
+    qtbot.addWidget(bubble)
+    with qtbot.waitSignal(bubble.retry_requested) as blocker:
+        # 取重新傳送 action 並觸發
+        for a in bubble._build_context_menu().actions():
+            if a.text() == "重新傳送":
+                a.trigger()
+                break
+    assert blocker.args == [42]

--- a/to-do.md
+++ b/to-do.md
@@ -80,7 +80,7 @@
 ### 3C 次要/邊角畫面（可選，優先度低）
 - [ ] 連線狀態 banner（重連中/失敗）— artboard 24-25（部分已有）
 - [ ] 空狀態（全新使用者）— artboard 26
-- [ ] 送訊息失敗 + 重試 — artboard 28
+- [x] 送訊息失敗 + 重試 — artboard 28。`db.get_message_content` 取回編碼內容；ChatBubble `retry_requested`（is_me+failed 才顯示「重新傳送」）；`handle_retry_message` 翻 pending + 同 msg_id re-enqueue（走既有 `_do_send`，不動 worker）；失敗回饋改狀態列非阻斷提示（不再彈 QMessageBox）。@ `feature/app-msg-retry`
 - [ ] 系統通知 / App toast — artboard 39-40（現有 tray）
 - [ ] 登入錯誤三分態（密碼錯/踢線/維護）— artboard 41-43 · **受限**：PyPtt 無法可靠區分維護/踢線（見 memory `project_pyptt_login_errors`），只能做可分辨的
 - [ ] 初次同步 loading/skeleton — artboard 44


### PR DESCRIPTION
## 這個 PR 做什麼

讓發送失敗的自訊息可以「重新傳送」,並把失敗回饋從阻斷式 `QMessageBox` 改為狀態列非阻斷提示(artboard 28)。動到 send 佇列的地方一律走既有路徑、不改 worker。

## 內容

| # | Task | 檔案 |
|---|---|---|
| 1 | `get_message_content(account_id, msg_id) -> Optional[str]` — 取回該 row 存的編碼後 `content` 供重送 | `db.py` |
| 2 | ChatBubble `retry_requested = Signal(int)`;`_build_context_menu` 在 `is_me and send_status=='failed'` 時加「重新傳送」 | `widgets.py` |
| 3 | `handle_retry_message(msg_id)`:狀態翻回 pending(DB+快取+畫面)、重用同 `msg_id` re-enqueue(走既有 `_do_send`,不動 worker);建泡泡處接線 | `screens.py` |
| 4 | `on_send_result` 失敗路徑移除 `QMessageBox.warning`,改 `_flash_status` 狀態列閃現(5s 還原),引導使用者右鍵重送 | `screens.py` |
| 5 | 測試(見下) | `tests/` |

## 測試

`QT_QPA_PLATFORM=offscreen pytest` → **284 passed / 0 failed**。新增:
- `get_message_content`(正常 / 未知 None)
- `handle_retry_message`(同 msg_id re-enqueue、failed→pending、內容缺則 no-op)
- `ChatBubble` 選單(failed 有「重新傳送」;sent/pending/received 無;emit 正確 msg_id)
- 既有 `on_send_result` 失敗測試改對齊非阻斷提示(不再斷言 `QMessageBox`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rpx2T6Nnwra7gLDg7toKQF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rpx2T6Nnwra7gLDg7toKQF)_