### PR TITLE
refactor: Phase 3A 延後的 5 個 Minor 清理(去重複／匯入一致／小瑕疵)

### DIFF
--- a/src/uPtt/db.py
+++ b/src/uPtt/db.py
@@ -7,6 +7,17 @@ from typing import List, Dict, Any, Optional
 
 logger = logging.getLogger(__name__)
 
+
+def _strip_reply_prefix(text: str) -> str:
+    """把回覆包裝 `[re:@sender|preview]\\n` 剝掉，只留實際內容（供 session 摘要用）。
+
+    與 utils.decode_reply 同語意，但刻意在此保留獨立純字串實作，避免 db 這層
+    為了剝前綴而耦合到 PySide6-heavy 的 utils 模組。"""
+    if text.startswith('[re:@') and ']\n' in text:
+        return text[text.index(']\n') + 2:]
+    return text
+
+
 class DatabaseManager:
     """
     uPtt 資料庫管理器，支援多帳號隔離。
@@ -156,6 +167,19 @@ class DatabaseManager:
                 conn.commit()
         except sqlite3.Error as e:
             logger.error(f"更新帳號失敗：{e}")
+
+    def get_account_display_id(self, account_id: str) -> str:
+        """回傳帳號的顯示用 ID（正確大小寫）。查無則回傳傳入值本身。"""
+        try:
+            with self._get_connection() as conn:
+                row = conn.execute(
+                    "SELECT display_id FROM accounts WHERE id = ?", (account_id.lower(),)
+                ).fetchone()
+                if row and row['display_id']:
+                    return row['display_id']
+        except sqlite3.Error as e:
+            logger.error(f"查詢帳號顯示 ID 失敗：{e}")
+        return account_id
 
     # --- 會話與聯絡人 (需傳入 account_id) ---
 
@@ -333,8 +357,7 @@ class DatabaseManager:
                 """, (acc_id_lower, session_id)).fetchone()
 
                 summary = next_msg['content'] if next_msg else ''
-                if summary.startswith('[re:@') and ']\n' in summary:
-                    summary = summary[summary.index(']\n') + 2:]
+                summary = _strip_reply_prefix(summary)
                 last_time = next_msg['timestamp'] if next_msg else None
 
                 conn.execute("""
@@ -371,8 +394,7 @@ class DatabaseManager:
                 # 2. 更新會話摘要並強制設為可見 (收到新訊息或發送訊息時)
                 # 若為回覆訊息格式，摘要只顯示實際內容部分
                 summary = content
-                if summary.startswith('[re:@') and ']\n' in summary:
-                    summary = summary[summary.index(']\n') + 2:]
+                summary = _strip_reply_prefix(summary)
 
                 if is_me:
                     conn.execute("""
@@ -424,8 +446,7 @@ class DatabaseManager:
                 msg_id = cursor.lastrowid
 
                 summary = content
-                if summary.startswith('[re:@') and ']\n' in summary:
-                    summary = summary[summary.index(']\n') + 2:]
+                summary = _strip_reply_prefix(summary)
                 conn.execute("""
                     UPDATE sessions SET
                         last_message_text = CASE

--- a/src/uPtt/ui/screens.py
+++ b/src/uPtt/ui/screens.py
@@ -14,15 +14,17 @@ from PySide6.QtCore import Qt, Signal, Slot, QThread, QSize, QEvent, QUrl, QTime
 from PySide6.QtGui import QIcon, QAction, QShortcut, QKeySequence, QPixmap, QPainter, QFontMetrics, QDesktopServices, QIntValidator
 from PySide6.QtSvg import QSvgRenderer
 
+# 同套件（uPtt.ui.*）一律相對匯入、跨套件用絕對匯入。相對匯入亦確保
+# render_svg 等 re-export 在專案 src.uPtt/uPtt 雙重載入下維持同一模組物件。
 from uPtt import __version__, config, contant
-from uPtt.ui import theme
-from uPtt.ui.settings import SettingsWindow
-from uPtt.ui.search_palette import SearchPalette
-from uPtt.ui.new_chat_modal import NewChatModal
-from uPtt.ui.profile_panel import ProfilePanel
-from uPtt.ui.styles import build_main_style
+from . import theme
+from .settings import SettingsWindow
+from .search_palette import SearchPalette
+from .new_chat_modal import NewChatModal
+from .profile_panel import ProfilePanel
+from .styles import build_main_style
 from .theme import FONT_STACK, ASSETS_DIR, render_svg
-from uPtt.ui.widgets import ChatBubble, WaterballBubble, MailCard, ContactItem, ContactListWidget
+from .widgets import ChatBubble, WaterballBubble, MailCard, ContactItem, ContactListWidget
 from uPtt.utils import encode_reply, decode_reply, VersionCheckWorker, resolve_display_name
 from uPtt.worker import PTTWorker, QueryWorker
 from uPtt.ptt import UPttService
@@ -1847,7 +1849,7 @@ class MainWindow(QMainWindow):
                 'mail_type': m.get('mail_type', 'uptt'),
                 'subject': m.get('subject', ''),
                 'reply_info': reply_info,
-                'msg_id': m.get('id', -1),
+                'msg_id': m.get('id'),
             }
             if entry['is_me']:
                 entry['send_status'] = m.get('send_status') or 'sent'
@@ -2020,6 +2022,9 @@ class MainWindow(QMainWindow):
             if widget and widget.ptt_id == session_id:
                 widget.set_last_msg_time(_format_contact_time(row.get('last_message_time', '') if row else ''))
                 break
+        # 刪最新訊息會讓該會話 last_message_time 回退，需即時依時間重排到正確位置
+        # （否則順序會暫時錯，得等下次事件才自癒）。
+        self._reposition_contact_by_time(session_id, sessions)
 
     def _get_contact_display_id(self, ptt_id_lower: str) -> str:
         for i in range(self.contact_list.count()):
@@ -2290,6 +2295,41 @@ class MainWindow(QMainWindow):
         self.contact_list.setItemWidget(new_item, new_widget)
         return new_item
 
+    def _reposition_contact_by_time(self, session_id: str, sessions: list):
+        """依 DB 時間排序，把非釘選聯絡人移到正確位置。sessions 為 get_all_sessions
+        結果（非釘選段已按 last_message_time DESC）。釘選段為手動排序，不動。"""
+        if session_id in self.pinned_ids:
+            return
+        pinned_count = self.contact_list._pinned_count()
+        unpinned_order = [s['id'] for s in sessions if not s.get('is_pinned')]
+        if session_id not in unpinned_order:
+            return
+        target_row = pinned_count + unpinned_order.index(session_id)
+
+        cur_row = -1
+        for i in range(self.contact_list.count()):
+            w = self.contact_list.itemWidget(self.contact_list.item(i))
+            if w and w.ptt_id == session_id:
+                cur_row = i
+                break
+        if cur_row < 0 or cur_row == target_row:
+            return
+
+        item = self.contact_list.item(cur_row)
+        widget = self.contact_list.itemWidget(item)
+        was_selected = (self.contact_list.currentItem() == item)
+        data = widget.get_data()
+        self.contact_list.removeItemWidget(item)
+        self.contact_list.takeItem(cur_row)
+        # target_row 是該項在 unpinned_order 的絕對位置；移除後其餘項相對序不變，
+        # 直接插到 target_row 即重建正確順序（含末端 append 情形）。
+        new_item = self._rebuild_contact_item(data, target_row, False)
+        unread = self.unread_counts.get(session_id, 0)
+        if unread > 0:
+            self.contact_list.itemWidget(new_item).set_unread(unread)
+        if was_selected:
+            self.contact_list.setCurrentItem(new_item)
+
     def _move_contact_to_top(self, sender: str):
         """將指定非釘選聯絡人移至非釘選區頂端 (sender 為小寫)"""
         if sender in self.pinned_ids:
@@ -2414,12 +2454,14 @@ class MainWindow(QMainWindow):
             return
 
         messages = self.db.get_messages(current_acc, ptt_id_lower, limit=None)
+        # 本人訊息的 sender 取帳號的權威顯示 ID（正確大小寫），與對方用 display_name 一致。
+        me_display = self.db.get_account_display_id(current_acc)
         lines = []
         for m in messages:
             ts = m['timestamp']
             ts_dt = datetime.fromisoformat(ts) if isinstance(ts, str) else ts
             ts_str = ts_dt.strftime('%Y-%m-%d %H:%M:%S')
-            sender = current_acc if m['is_me'] else display_name
+            sender = me_display if m['is_me'] else display_name
             _, text = decode_reply(m['content'])
             lines.append(f"[{ts_str}] {sender}: {text}")
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -586,3 +586,32 @@ def test_search_messages_escapes_wildcards(db_manager):
     # 經典注入字串應查無資料且不刪表
     assert db_manager.search_messages(acc, "'; DROP TABLE messages;--") == []
     assert db_manager.search_messages(acc, "50%")  # messages 表仍在
+
+
+def test_strip_reply_prefix():
+    from uPtt.db import _strip_reply_prefix
+    # 有回覆包裝 → 只留實際內容
+    assert _strip_reply_prefix("[re:@bob|原文預覽]\n實際內容") == "實際內容"
+    # 無包裝 → 原樣
+    assert _strip_reply_prefix("一般訊息") == "一般訊息"
+    # 有前綴樣但無換行分隔 → 不誤剝
+    assert _strip_reply_prefix("[re:@bob|x] 沒換行") == "[re:@bob|x] 沒換行"
+
+
+def test_get_account_display_id(db_manager):
+    db_manager.upsert_account("TestUser", "TestUser", "Nick")
+    # 以小寫 key 查得正確大小寫顯示 ID
+    assert db_manager.get_account_display_id("testuser") == "TestUser"
+    assert db_manager.get_account_display_id("TestUser") == "TestUser"
+    # 查無帳號 → 回傳傳入值本身
+    assert db_manager.get_account_display_id("ghost") == "ghost"
+
+
+def test_session_summary_strips_reply_wrapper(db_manager):
+    """save_message 後,session 摘要應剝掉回覆包裝(驗證 _strip_reply_prefix 接線)。"""
+    acc, sid = "alice", "bob"
+    db_manager.upsert_account(acc, acc)
+    db_manager.upsert_session(acc, sid)
+    db_manager.save_message(acc, sid, sid, acc, "[re:@alice|你說的]\n這是回覆", datetime.now(), False)
+    sessions = db_manager.get_all_sessions(acc)
+    assert sessions[0]['last_message_text'] == "這是回覆"

--- a/tests/test_ui_screens.py
+++ b/tests/test_ui_screens.py
@@ -851,6 +851,7 @@ def test_export_chat_history_writes_txt_file(mock_qthread, mock_worker, mock_que
         {'content': 'Hello', 'timestamp': '2026-01-01 12:00:00', 'is_me': 0},
         {'content': 'Hi back', 'timestamp': '2026-01-01 12:01:00', 'is_me': 1},
     ]
+    db_mock.get_account_display_id.return_value = "MyID"  # 本人 sender 取權威顯示 ID
     with patch('os.path.exists', return_value=True):
         window = MainWindow(ptt_service_mock, ptt_query_service_mock, db_mock)
         qtbot.addWidget(window)
@@ -932,3 +933,56 @@ def test_load_sessions_shows_mute_icon_for_muted_session(mock_qthread, mock_work
         widget = window.contact_list.itemWidget(window.contact_list.item(0))
         assert widget._is_muted is True
         assert widget.mute_icon_label.isVisible() is True
+
+
+@patch('src.uPtt.ui.screens.VersionCheckWorker')
+@patch('src.uPtt.ui.screens.QueryWorker')
+@patch('src.uPtt.ui.screens.PTTWorker')
+@patch('src.uPtt.ui.screens.QThread')
+def test_reposition_contact_by_time_moves_to_correct_row(
+        mock_qthread, mock_worker, mock_query_worker, mock_ver_worker,
+        qtbot, ptt_service_mock, ptt_query_service_mock, db_mock):
+    """刪最新訊息後,依 DB 時間排序把該聯絡人即時移到正確位置(Minor 5)。"""
+    with patch('os.path.exists', return_value=True):
+        window = MainWindow(ptt_service_mock, ptt_query_service_mock, db_mock)
+        qtbot.addWidget(window)
+        for name in ("Alice", "Bob", "Carol"):
+            window.add_or_select_contact(name)
+
+    def ids():
+        return [window.contact_list.itemWidget(window.contact_list.item(i)).ptt_id
+                for i in range(window.contact_list.count())]
+
+    order = ids()
+    assert set(order) == {"alice", "bob", "carol"}
+    top = order[0]
+
+    # 模擬 top 的最新訊息被刪 → 其 last_message_time 回退,DB 排序改把它放最末
+    others = [x for x in order if x != top]
+    sessions = [{'id': x, 'is_pinned': 0} for x in others] + [{'id': top, 'is_pinned': 0}]
+    window._reposition_contact_by_time(top, sessions)
+
+    assert ids() == others + [top]  # top 已下移到底端
+
+
+@patch('src.uPtt.ui.screens.VersionCheckWorker')
+@patch('src.uPtt.ui.screens.QueryWorker')
+@patch('src.uPtt.ui.screens.PTTWorker')
+@patch('src.uPtt.ui.screens.QThread')
+def test_reposition_contact_noop_when_already_correct(
+        mock_qthread, mock_worker, mock_query_worker, mock_ver_worker,
+        qtbot, ptt_service_mock, ptt_query_service_mock, db_mock):
+    with patch('os.path.exists', return_value=True):
+        window = MainWindow(ptt_service_mock, ptt_query_service_mock, db_mock)
+        qtbot.addWidget(window)
+        for name in ("Alice", "Bob"):
+            window.add_or_select_contact(name)
+
+    def ids():
+        return [window.contact_list.itemWidget(window.contact_list.item(i)).ptt_id
+                for i in range(window.contact_list.count())]
+
+    order = ids()
+    sessions = [{'id': x, 'is_pinned': 0} for x in order]  # 已是正確順序
+    window._reposition_contact_by_time(order[0], sessions)
+    assert ids() == order  # 不變

--- a/to-do.md
+++ b/to-do.md
@@ -51,7 +51,12 @@
 
 > **核心 4 項已完成 ✅** @ `feature/app-redesign`（2026-07-24，commits `083b1cd..6c2168d`，10 個 commit，232→239 測試綠，最終 opus whole-branch review = Ready to merge）。spec `specs/2026-07-24-app-phase3a-menu-actions-design.md`、計畫 `specs/2026-07-24-app-phase3a-menu-actions-plan.md`。流程：brainstorm→spec→plan→subagent-driven 逐 task（developer 實作 + fresh verifier 兩段驗收）+ opus 最終審。
 > 附帶結構調整：`render_svg`/`ASSETS_DIR` 搬到 `theme.py` 解 widgets↔screens 循環 import（screens 保留 re-export）。
-> 延後 5 個 Minor（全外觀、無 bug）：`[re:@]` 剝除邏輯重複、export 自訊息 sender 用帳號 ID、`screens.py` import 風格混用、`m.get('id',-1)` 宜改 `None`、刪最新訊息時聯絡人列未即時重排（自癒）。
+> ~~延後 5 個 Minor~~ **✅ 已全數處理** @ `feature/app-phase3a-minors`（2026-07-24，281 測試綠）：
+> 1. `[re:@]` 剝除重複 → db.py 抽 `_strip_reply_prefix`，3 處併 1
+> 2. export 自訊息 sender → 改用 `db.get_account_display_id`（權威正確大小寫）
+> 3. `screens.py` import 風格混用 → 同套件一律相對、跨套件絕對（相對亦維持 render_svg re-export 同一物件）
+> 4. `m.get('id',-1)` → `m.get('id')`（None；讓無 id 泡泡正確隱藏刪除項）
+> 5. 刪最新訊息聯絡人列未即時重排 → 新增 `_reposition_contact_by_time`，刪後依 DB 時序即時下移
 
 - [x] 訊息 · **刪除（僅本機）**（32）— 新增 `db.delete_message` + 確認框；無 id 的泡泡不出現刪除項
 - [x] 聯絡人 · **重新命名…**（17）— 新增本機 `custom_name` 欄，顯示序 `custom_name > PTT nickname > display_id`，PTT 查詢不覆寫；空字串還原


### PR DESCRIPTION
## 這個 PR 做什麼

處理 Phase 3A code review 當時延後的 5 個 Minor。#1/#2/#3 是純內部整理(使用者無感);#4/#5 順手修掉兩個小瑕疵。

## 內容

1. **`[re:@]` 剝除重複**(`db.py`)— session 摘要剝掉回覆包裝的邏輯,原本在 3 處各寫一份,抽成 `_strip_reply_prefix` helper 併為 1。刻意不 import `utils`(避免 db 這層耦合 PySide6-heavy 的 utils)。

2. **export 自訊息 sender**(`db.py` + `screens.py`)— 新增 `get_account_display_id`(從 `accounts` 表取權威正確大小寫),export 本人 sender 改用它。**輸出內容不變**,只是來源改成單一權威處。

3. **import 風格混用**(`screens.py`)— 同套件(`uPtt.ui.*`)一律相對匯入、跨套件絕對。相對匯入亦確保 `render_svg` 等 re-export 在專案 `src.uPtt`/`uPtt` 雙載入下維持同一模組物件(改絕對會打爆 `test_theme` 的身分斷言)。

4. **`m.get('id', -1)` → `m.get('id')`**(`screens.py`)— 無 DB id 的泡泡 `msg_id` 改 `None`,讓 `ChatBubble` 的 `is not None` gate 正確**隱藏「刪除」項**(原 `-1` 會誤顯示,雖點了是 no-op)。

5. **刪最新訊息聯絡人列未即時重排**(`screens.py`)— 新增 `_reposition_contact_by_time`,刪掉最新訊息後其 `last_message_time` 回退,依 `get_all_sessions` 時序**即時把該聯絡人下移**到正確位置(不再等下次事件自癒)。

## 測試

`QT_QPA_PLATFORM=offscreen pytest` → **281 passed / 0 failed**。新增:`_strip_reply_prefix`、`get_account_display_id`(正常/None)、session 摘要剝除、`_reposition_contact_by_time`(下移 + noop)。

> 註:與 PR #30(送訊息失敗重試)彼此獨立,分別從 `beta` 開出。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rpx2T6Nnwra7gLDg7toKQF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rpx2T6Nnwra7gLDg7toKQF)_