### PR TITLE
feat(ui): 主題 Mono 改為 Kraft 再生紙(暖色系 + 紙纖維貼圖)

### DIFF
--- a/src/uPtt/ui/settings.py
+++ b/src/uPtt/ui/settings.py
@@ -25,7 +25,7 @@ logger = logging.getLogger("uPtt.settings")
 _THEME_META = {
     'graphite': {'name': 'Graphite', 'tag': '深色 · 冷灰中性 + 鼠尾草綠'},
     'bone': {'name': 'Bone', 'tag': '淺色 · 冷灰白'},
-    'mono': {'name': 'Mono', 'tag': '純黑白 · 排版至上'},
+    'kraft': {'name': '再生紙', 'tag': '暖色 · 再生紙感'},
 }
 
 
@@ -140,7 +140,7 @@ class ThemeCard(QFrame):
         self.theme_id = theme_id
         self._selected = False
         self.setCursor(Qt.PointingHandCursor)
-        self.setFixedSize(116, 116)  # tag 最長兩行需要的高度（如 mono 的「純黑白‧排版至上」）
+        self.setFixedSize(116, 116)  # tag 最長兩行需要的高度（如 graphite 的「深色‧冷灰中性 + 鼠尾草綠」）
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(10, 10, 10, 8)

--- a/src/uPtt/ui/styles.py
+++ b/src/uPtt/ui/styles.py
@@ -23,6 +23,25 @@ def build_main_style() -> str:
     accent_bg = t["accent_bg"]
     accent_bg_hover = t["accent_bg_hover"]
     danger = t["danger"]
+    paper_texture = t["paper_texture"]
+
+    # 紙纖維貼圖只精準命中訊息內容 widget 這個單一表面（避免全域規則在每個
+    # 子 widget 各自重新平鋪造成接縫）；token 為空字串時（graphite/bone）整條不輸出。
+    #
+    # 注意：Qt QSS 的 `background-image` + `background-repeat` 這兩個 longhand
+    # 屬性組合實測不會平鋪，只會在原點畫一次。要平鋪必須走 `background` shorthand
+    # （background: url(...) repeat;），但 shorthand 會把 background-color 重置掉，
+    # 所以下面在同一個規則區塊裡，於 shorthand 之後再補一次 background-color 覆蓋回來。
+    paper_texture_rule = (
+        f"""
+#messages-container {{
+    background: url({paper_texture}) repeat;
+    background-color: {bg};
+}}
+"""
+        if paper_texture
+        else ""
+    )
 
     return f"""
 /* 全域字體與背景 */
@@ -187,7 +206,7 @@ QLineEdit#new-chat-input:focus {{
 #messages-container {{
     background-color: {bg};
 }}
-
+{paper_texture_rule}
 /* 訊息輸入區 */
 #input-area {{
     background-color: {surface};

--- a/src/uPtt/ui/theme.py
+++ b/src/uPtt/ui/theme.py
@@ -1,6 +1,6 @@
 # --- uPtt UI 色票 / 字型 token（單一色源）+ 主題切換引擎 ---
 #
-# 三組主題 Graphite / Bone / Mono，key 完全一致。所有畫面的顏色都應該從
+# 三組主題 Graphite / Bone / Kraft，key 完全一致。所有畫面的顏色都應該從
 # `active()` 取值，不要在各處硬寫 hex。
 
 import os
@@ -80,6 +80,7 @@ GRAPHITE = {
     "status_connecting": "#D29922",
     "msg_pending": "#5C6773",
     "archived_text": "#6E4040",
+    "paper_texture": "",  # 只有 kraft 有紙纖維貼圖，其餘 theme 維持純色
 }
 
 
@@ -112,44 +113,47 @@ BONE = {
     "status_connecting": "#9A6700",  # beta 分支 warn 權威值（淺底暖金）
     "msg_pending": "#5C6470",  # canvas：送出中 == muted
     "archived_text": "#9E5C4C",  # 推導：淺底暗紅（封存/不存在）
+    "paper_texture": "",  # 只有 kraft 有紙纖維貼圖，其餘 theme 維持純色
 }
 
 
-# Mono：純灰階淺色主題（白底、黑字、近黑 accent）。base 取自畫布 ground-truth；
-# 缺的 token 依 base 推導。★標記處為刻意偏離畫布的判斷，可依喜好改。
-MONO = {
-    "bg": "#F7F7F7",           # canvas
-    "surface": "#EFEFEF",      # canvas
-    "surface_hover": "#E7E7E7",  # 推導
-    "surface_2": "#FFFFFF",    # canvas
+# Kraft：暖色系再生紙筆記本主題（暖燕麥紙底、石墨褐字、赭黃 accent）。
+# 取代舊版 Mono（純灰階去彩度，跟 Bone 太像），色值為手動指定的暖色票。
+KRAFT = {
+    "bg": "#E9E3D6",
+    "surface": "#E0D9CA",
+    "surface_hover": "#D7CFBD",
+    "surface_2": "#F4F0E6",
 
-    "border": "rgba(0, 0, 0, 0.16)",         # canvas
-    "border_strong": "rgba(0, 0, 0, 0.20)",  # canvas
+    "border": "rgba(58, 46, 30, 0.16)",
+    "border_strong": "rgba(58, 46, 30, 0.24)",
 
-    "text": "#0A0A0A",         # canvas
-    "text_muted": "#6A6A6A",   # canvas
-    "text_faint": "#A8A8A8",   # canvas
+    "text": "#33291E",
+    "text_muted": "#6E6152",
+    "text_faint": "#A2957F",
 
-    "accent": "#0A0A0A",       # canvas（近黑，零彩度）
-    "accent_hover": "#2E2E2E",   # 推導
-    "accent_bg": "#E4E4E4",    # canvas
-    "accent_bg_hover": "#D7D7D7",  # 推導
-    "accent_tint_hover": "#DEDEDE",  # 推導
+    "accent": "#8C5E1C",
+    "accent_hover": "#6F4913",
+    "accent_bg": "#E3D4B4",
+    "accent_bg_hover": "#D8C6A0",
+    "accent_tint_hover": "#EFE6D0",
 
-    "danger": "#B33A20",       # canvas（唯一暖色）★純黑白可改灰
-    "danger_strong": "#8C2C16",  # 推導
+    "danger": "#9E3428",
+    "danger_strong": "#7A2419",
 
-    "status_online": "#0A0A0A",   # canvas：online == accent == 黑
-    "status_unknown": "#A8A8A8",  # 推導：灰
-    "status_connecting": "#8A8A8A",  # beta 分支 warn 權威值（灰階）
-    "msg_pending": "#6A6A6A",  # canvas：送出中 == muted
-    "archived_text": "#8A8A8A",  # 推導：灰階
+    "status_online": "#5F7A3C",
+    "status_unknown": "#B3A894",
+    "status_connecting": "#8A7A55",
+    "msg_pending": "#8A7E6C",
+    "archived_text": "#8F6550",
+    # 紙纖維雜點貼圖：極淡、可平鋪的 64x64 PNG，僅套在訊息區內容 widget（單一表面，無接縫問題）
+    "paper_texture": os.path.join(ASSETS_DIR, "paper_fiber_kraft.png").replace("\\", "/"),
 }
 
 
 # --- 主題切換引擎 ---
 
-THEMES = {"graphite": GRAPHITE, "bone": BONE, "mono": MONO}
+THEMES = {"graphite": GRAPHITE, "bone": BONE, "kraft": KRAFT}
 
 _current = "graphite"
 
@@ -217,7 +221,7 @@ if __name__ == "__main__":
     set_theme("graphite")
     assert active() is GRAPHITE, "set_theme('graphite') 應復原"
 
-    assert set(GRAPHITE.keys()) == set(BONE.keys()) == set(MONO.keys()), (
+    assert set(GRAPHITE.keys()) == set(BONE.keys()) == set(KRAFT.keys()), (
         "三個 palette 的 key 必須完全一致"
     )
 
@@ -232,7 +236,7 @@ if __name__ == "__main__":
     before = len(_restyles)
     # 手動替換成會炸的 fn，模擬 apply_theme 走到它時 widget 已被刪
     _restyles[-1] = (weakref.ref(fake), _boom)
-    apply_theme("mono")
+    apply_theme("kraft")
     assert len(_restyles) == before - 1, "fn 丟 RuntimeError 的項目應被剪除"
 
     set_theme("graphite")

--- a/tests/test_ui_settings.py
+++ b/tests/test_ui_settings.py
@@ -68,7 +68,7 @@ def test_theme_card_click_emits_theme_id(qtbot):
 
 
 def test_theme_card_set_selected_updates_flag(qtbot):
-    card = ThemeCard("mono", theme.THEMES["mono"])
+    card = ThemeCard("kraft", theme.THEMES["kraft"])
     qtbot.addWidget(card)
     assert card._selected is False
     card.set_selected(True)
@@ -101,11 +101,11 @@ def test_click_theme_card_applies_and_persists_theme(qtbot, db_mock):
     win = SettingsWindow(db_mock)
     qtbot.addWidget(win)
 
-    qtbot.mouseClick(win._theme_cards["mono"], Qt.LeftButton)
+    qtbot.mouseClick(win._theme_cards["kraft"], Qt.LeftButton)
 
-    assert theme.current_theme() == "mono"
-    db_mock.set_config.assert_any_call(config.SETTING_THEME, "mono")
-    assert win._theme_cards["mono"]._selected is True
+    assert theme.current_theme() == "kraft"
+    db_mock.set_config.assert_any_call(config.SETTING_THEME, "kraft")
+    assert win._theme_cards["kraft"]._selected is True
     assert win._theme_cards["graphite"]._selected is False
 
 


### PR DESCRIPTION
## 內容
- `theme.py`：刪掉 `MONO`（純灰階，跟 Bone 太像），換成 `KRAFT` 暖色票（暖燕麥紙底／石墨褐字／赭黃 accent）
- 新增 `paper_texture` token：graphite/bone 為空字串，只有 kraft 有貼圖
- `styles.py`：紙纖維貼圖只套在 `#messages-container` 單一表面，避免子 widget 各自平鋪產生接縫。附註 Qt QSS 要用 `background` shorthand 才會 repeat 的踩坑
- `settings.py` / `test_ui_settings.py`：主題卡片與測試 `mono` → `kraft`

## 測試
`QT_QPA_PLATFORM=offscreen pytest` → 298 passed

## 注意
`src/uPtt/ui/assets/paper_fiber_kraft.png` 還沒進 git，合併前要補上，否則 kraft 主題只會是純色（不會炸）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MtpnRyWCXu7kd3ik7WwjB