### PR TITLE
Add VIP account system with kraft theme exclusivity

### DIFF
--- a/src/uPtt/ui/screens.py
+++ b/src/uPtt/ui/screens.py
@@ -16,7 +16,7 @@ from PySide6.QtSvg import QSvgRenderer
 
 # 同套件（uPtt.ui.*）一律相對匯入、跨套件用絕對匯入。相對匯入亦確保
 # render_svg 等 re-export 在專案 src.uPtt/uPtt 雙重載入下維持同一模組物件。
-from uPtt import __version__, config, contant
+from uPtt import __version__, config, contant, vip
 from . import theme
 from .settings import SettingsWindow
 from .search_palette import SearchPalette
@@ -704,6 +704,7 @@ class MainWindow(QMainWindow):
         self._user_info_cache: Dict[str, Dict] = {}  # ptt_id_lower -> user info dict
         self.session_drafts: Dict[str, str] = {}  # ptt_id_lower -> draft text
         self._quitting = False  # 退出程序旗標，防止遞迴
+        self._is_vip = False  # 登入成功後由 on_login_result 依 vip.is_vip_account() 判定
         self._settings_window: Optional[SettingsWindow] = None  # 單例，重複開就 raise/activate
         self._search_palette: Optional[SearchPalette] = None  # ⌘K 搜尋面板，單例
         self._new_chat_modal: Optional[NewChatModal] = None  # ⌘N 新對話 modal，單例
@@ -1273,7 +1274,8 @@ class MainWindow(QMainWindow):
         """開啟偏好設定視窗（單例：重複觸發只 raise/activate 既有視窗，不重建）。"""
         if self._settings_window is None:
             self._settings_window = SettingsWindow(
-                self.db, worker=getattr(self, 'worker', None), query_worker=getattr(self, 'query_worker', None)
+                self.db, worker=getattr(self, 'worker', None), query_worker=getattr(self, 'query_worker', None),
+                is_vip=self._is_vip,
             )
         self._settings_window.show()
         self._settings_window.raise_()
@@ -1454,6 +1456,11 @@ class MainWindow(QMainWindow):
         self.scan_setup_screen.reset()
         self.central_stack.setCurrentIndex(2)
 
+    def _window_title(self, suffix: str = "") -> str:
+        """組出標題列文字：uPtt - {帳號}[ · VIP][suffix]。VIP 標記依登入時判定的 self._is_vip。"""
+        vip_tag = " · VIP" if self._is_vip else ""
+        return f"uPtt - {self.ptt_service.ptt_id}{vip_tag}{suffix}"
+
     def on_login_result(self, success, message):
         if success:
             # 登入成功，解除固定大小並調整為聊天視窗大小
@@ -1467,7 +1474,8 @@ class MainWindow(QMainWindow):
                 theme.apply_theme(account_theme)
 
             corrected_id = self.ptt_service.ptt_id
-            self.setWindowTitle(f"uPtt - {corrected_id}")
+            self._is_vip = vip.is_vip_account(corrected_id)
+            self.setWindowTitle(self._window_title())
             self.user_id_label.setText(corrected_id)
             self._status_dot.show()
             self.menu_btn.show()
@@ -1508,7 +1516,7 @@ class MainWindow(QMainWindow):
         self._status_dot._conn_state = "connecting"
         _restyle_conn_status_dot(self._status_dot)
         self._status_dot.setToolTip("連線中斷，正在重新連線...")
-        self.setWindowTitle(f"uPtt - {self.ptt_service.ptt_id} (重新連線中...)")
+        self.setWindowTitle(self._window_title(" (重新連線中...)"))
 
     @Slot()
     def on_connection_restored(self):
@@ -1517,7 +1525,7 @@ class MainWindow(QMainWindow):
         self._status_dot._conn_state = "online"
         _restyle_conn_status_dot(self._status_dot)
         self._status_dot.setToolTip("")
-        self.setWindowTitle(f"uPtt - {self.ptt_service.ptt_id}")
+        self.setWindowTitle(self._window_title())
 
     @Slot()
     def on_query_session_degraded(self):
@@ -2404,7 +2412,7 @@ class MainWindow(QMainWindow):
                     self.current_chat_id = None
                     self.set_active_chat_requested.emit("")
                     self.refresh_chat_display()
-                    self.setWindowTitle(f"uPtt - {self.ptt_service.ptt_id}")
+                    self.setWindowTitle(self._window_title())
                 break
 
     def toggle_pin(self, ptt_id: str):

--- a/src/uPtt/ui/settings.py
+++ b/src/uPtt/ui/settings.py
@@ -9,8 +9,8 @@ import logging
 from PySide6.QtCore import Qt, QMetaObject, Signal
 from PySide6.QtGui import QFont, QColor, QPainter, QPen
 from PySide6.QtWidgets import (
-    QCheckBox, QFrame, QGridLayout, QHBoxLayout, QLabel, QSpinBox, QTabWidget,
-    QVBoxLayout, QWidget,
+    QCheckBox, QFrame, QGraphicsOpacityEffect, QGridLayout, QHBoxLayout, QLabel,
+    QSpinBox, QTabWidget, QToolTip, QVBoxLayout, QWidget,
 )
 
 from uPtt import __version__, config, contant
@@ -25,7 +25,7 @@ logger = logging.getLogger("uPtt.settings")
 _THEME_META = {
     'graphite': {'name': 'Graphite', 'tag': '深色 · 冷灰中性 + 鼠尾草綠'},
     'bone': {'name': 'Bone', 'tag': '淺色 · 冷灰白'},
-    'kraft': {'name': '再生紙', 'tag': '暖色 · 再生紙感'},
+    'kraft': {'name': '再生紙', 'tag': 'VIP 專屬 · 暖色 · 再生紙感', 'vip_only': True},
 }
 
 
@@ -131,16 +131,24 @@ class ToggleSwitch(QCheckBox):
 
 class ThemeCard(QFrame):
     """單張主題預覽卡：name + tag + bg/surface/accent 色票，選中時套 accent 邊框。
-    點擊發射 clicked(theme_id)；選中狀態由外層容器（SettingsWindow）透過 set_selected() 控制。"""
+    點擊發射 clicked(theme_id)；選中狀態由外層容器（SettingsWindow）透過 set_selected() 控制。
+    locked=True（VIP 專屬主題但帳號非 VIP）時：卡片半透明、游標變禁止圖示、點擊不會
+    emit clicked，只彈出提示文字，不會套用/儲存該主題。"""
 
     clicked = Signal(str)
 
-    def __init__(self, theme_id: str, theme_dict: dict, parent=None):
+    def __init__(self, theme_id: str, theme_dict: dict, locked: bool = False, parent=None):
         super().__init__(parent)
         self.theme_id = theme_id
+        self.locked = locked
         self._selected = False
-        self.setCursor(Qt.PointingHandCursor)
+        self.setCursor(Qt.ForbiddenCursor if locked else Qt.PointingHandCursor)
         self.setFixedSize(116, 116)  # tag 最長兩行需要的高度（如 graphite 的「深色‧冷灰中性 + 鼠尾草綠」）
+
+        if locked:
+            opacity = QGraphicsOpacityEffect(self)
+            opacity.setOpacity(0.5)
+            self.setGraphicsEffect(opacity)
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(10, 10, 10, 8)
@@ -166,7 +174,8 @@ class ThemeCard(QFrame):
         layout.addWidget(swatch)
 
         meta = _THEME_META.get(theme_id, {'name': theme_id, 'tag': ''})
-        self._name_label = QLabel(meta['name'])
+        name_text = f"{meta['name']} 🔒" if locked else meta['name']
+        self._name_label = QLabel(name_text)
         layout.addWidget(self._name_label)
 
         self._tag_label = QLabel(meta['tag'])
@@ -176,6 +185,9 @@ class ThemeCard(QFrame):
         theme.register_restyle(self, _restyle_theme_card)
 
     def mousePressEvent(self, event):
+        if self.locked:
+            QToolTip.showText(event.globalPosition().toPoint(), "VIP 專屬主題", self)
+            return
         self.clicked.emit(self.theme_id)
         super().mousePressEvent(event)
 
@@ -308,11 +320,12 @@ class SettingsWindow(QWidget):
         通知對應 worker 的 apply_poll_intervals() 立即套用到執行中的計時器。
     """
 
-    def __init__(self, db, worker=None, query_worker=None, parent=None):
+    def __init__(self, db, worker=None, query_worker=None, is_vip: bool = False, parent=None):
         super().__init__(parent)
         self.db = db
         self.worker = worker
         self.query_worker = query_worker
+        self.is_vip = is_vip
 
         self.setWindowTitle("設定")
         self.setAttribute(Qt.WA_StyledBackground, True)
@@ -358,7 +371,9 @@ class SettingsWindow(QWidget):
         cards_layout = QHBoxLayout()
         cards_layout.setSpacing(10)
         for theme_id, theme_dict in theme.THEMES.items():
-            tcard = ThemeCard(theme_id, theme_dict)
+            meta = _THEME_META.get(theme_id, {})
+            locked = meta.get('vip_only', False) and not self.is_vip
+            tcard = ThemeCard(theme_id, theme_dict, locked=locked)
             tcard.set_selected(theme_id == self._selected_theme)
             tcard.clicked.connect(self._on_theme_card_clicked)
             self._theme_cards[theme_id] = tcard

--- a/src/uPtt/vip.py
+++ b/src/uPtt/vip.py
@@ -1,0 +1,19 @@
+# --- VIP 帳號判定 ---
+#
+# app 是純 client、沒有自己的後端可以核發資格，因此採用最輕量的作法：
+# 白名單存 sha256(ptt_id.lower()) 的 hex digest，不在原始碼中留下明文 ID。
+# 這不是防篡改機制（本地 code 本來就能被改），只是不讓帳號一眼被看到。
+
+import hashlib
+
+_VIP_ID_HASHES = {
+    # sha256(ptt_id.lower())
+}
+
+
+def is_vip_account(ptt_id: str) -> bool:
+    """回傳指定 PTT ID 是否為 VIP 帳號（大小寫不敏感）。"""
+    if not ptt_id:
+        return False
+    digest = hashlib.sha256(ptt_id.strip().lower().encode("utf-8")).hexdigest()
+    return digest in _VIP_ID_HASHES

--- a/src/uPtt/vip.py
+++ b/src/uPtt/vip.py
@@ -7,7 +7,8 @@
 import hashlib
 
 _VIP_ID_HASHES = {
-    # sha256(ptt_id.lower())
+    "6fbc54708c7fcf16ef15511919f203186bfb22bb53b6ad631796d0373a86f400",
+    "7d3850c0f2cdac6cf799a8a5b5f80c803ee250a5cf7f947337e11463661d3999",
 }
 
 

--- a/tests/test_ui_screens.py
+++ b/tests/test_ui_screens.py
@@ -109,6 +109,33 @@ def test_on_login_result_failure(mock_qthread, mock_worker, mock_query_worker, m
 @patch('src.uPtt.ui.screens.QueryWorker')
 @patch('src.uPtt.ui.screens.PTTWorker')
 @patch('src.uPtt.ui.screens.QThread')
+def test_on_login_result_title_has_no_vip_tag_for_regular_account(mock_qthread, mock_worker, mock_query_worker, mock_ver_worker, qtbot, ptt_service_mock, ptt_query_service_mock, db_mock):
+    with patch('os.path.exists', return_value=True):
+        window = MainWindow(ptt_service_mock, ptt_query_service_mock, db_mock)
+        qtbot.addWidget(window)
+        window.on_login_result(True, "Login Success")
+        assert window._is_vip is False
+        assert window.windowTitle() == "uPtt - MyID"
+
+
+@patch('src.uPtt.ui.screens.vip.is_vip_account', return_value=True)
+@patch('src.uPtt.ui.screens.VersionCheckWorker')
+@patch('src.uPtt.ui.screens.QueryWorker')
+@patch('src.uPtt.ui.screens.PTTWorker')
+@patch('src.uPtt.ui.screens.QThread')
+def test_on_login_result_title_shows_vip_tag_for_vip_account(mock_qthread, mock_worker, mock_query_worker, mock_ver_worker, mock_is_vip, qtbot, ptt_service_mock, ptt_query_service_mock, db_mock):
+    with patch('os.path.exists', return_value=True):
+        window = MainWindow(ptt_service_mock, ptt_query_service_mock, db_mock)
+        qtbot.addWidget(window)
+        window.on_login_result(True, "Login Success")
+        assert window._is_vip is True
+        assert window.windowTitle() == "uPtt - MyID · VIP"
+
+
+@patch('src.uPtt.ui.screens.VersionCheckWorker')
+@patch('src.uPtt.ui.screens.QueryWorker')
+@patch('src.uPtt.ui.screens.PTTWorker')
+@patch('src.uPtt.ui.screens.QThread')
 def test_first_time_login_shows_scan_screen(mock_qthread, mock_worker, mock_query_worker, mock_ver_worker, qtbot, ptt_service_mock, ptt_query_service_mock, db_mock):
     with patch('os.path.exists', return_value=True):
         window = MainWindow(ptt_service_mock, ptt_query_service_mock, db_mock)

--- a/tests/test_ui_settings.py
+++ b/tests/test_ui_settings.py
@@ -101,12 +101,42 @@ def test_click_theme_card_applies_and_persists_theme(qtbot, db_mock):
     win = SettingsWindow(db_mock)
     qtbot.addWidget(win)
 
+    qtbot.mouseClick(win._theme_cards["bone"], Qt.LeftButton)
+
+    assert theme.current_theme() == "bone"
+    db_mock.set_config.assert_any_call(config.SETTING_THEME, "bone")
+    assert win._theme_cards["bone"]._selected is True
+    assert win._theme_cards["graphite"]._selected is False
+
+
+# --- Kraft 主題為 VIP 專屬 ---
+
+def test_kraft_theme_locked_for_non_vip(qtbot, db_mock):
+    win = SettingsWindow(db_mock, is_vip=False)
+    qtbot.addWidget(win)
+
+    assert win._theme_cards["kraft"].locked is True
+
+    qtbot.mouseClick(win._theme_cards["kraft"], Qt.LeftButton)
+
+    # 鎖定卡片點擊不套用、不落 DB
+    assert theme.current_theme() != "kraft"
+    assert win._theme_cards["kraft"]._selected is False
+    for call in db_mock.set_config.call_args_list:
+        assert call.args != (config.SETTING_THEME, "kraft")
+
+
+def test_kraft_theme_unlocked_for_vip(qtbot, db_mock):
+    win = SettingsWindow(db_mock, is_vip=True)
+    qtbot.addWidget(win)
+
+    assert win._theme_cards["kraft"].locked is False
+
     qtbot.mouseClick(win._theme_cards["kraft"], Qt.LeftButton)
 
     assert theme.current_theme() == "kraft"
     db_mock.set_config.assert_any_call(config.SETTING_THEME, "kraft")
     assert win._theme_cards["kraft"]._selected is True
-    assert win._theme_cards["graphite"]._selected is False
 
 
 # --- 桌面通知開關：落 DB ---

--- a/tests/test_vip.py
+++ b/tests/test_vip.py
@@ -1,0 +1,22 @@
+import hashlib
+
+from src.uPtt import vip
+
+
+def test_non_whitelisted_account_is_not_vip():
+    assert vip.is_vip_account("SomeRandomUser") is False
+
+
+def test_empty_or_none_id_is_not_vip():
+    assert vip.is_vip_account("") is False
+    assert vip.is_vip_account(None) is False
+
+
+def test_whitelisted_hash_is_case_insensitive(monkeypatch):
+    digest = hashlib.sha256("viptester".encode("utf-8")).hexdigest()
+    monkeypatch.setattr(vip, "_VIP_ID_HASHES", {digest})
+
+    assert vip.is_vip_account("VipTester") is True
+    assert vip.is_vip_account("VIPTESTER") is True
+    assert vip.is_vip_account("viptester") is True
+    assert vip.is_vip_account("nottester") is False


### PR DESCRIPTION
## Summary
Implements a VIP account system that gates the kraft theme to VIP users only. Non-VIP accounts see a locked, semi-transparent kraft theme card that cannot be selected. VIP status is determined at login via a whitelist of hashed account IDs, and the window title displays a "· VIP" tag for VIP accounts.

## Key Changes

### VIP Account Detection (`src/uPtt/vip.py` - new)
- Created new module with `is_vip_account(ptt_id)` function
- Uses SHA256 hashes of lowercased PTT IDs to avoid storing plaintext credentials
- Case-insensitive account matching
- Whitelist stored as hex digests in `_VIP_ID_HASHES` set

### Theme Card Locking (`src/uPtt/ui/settings.py`)
- Added `locked` parameter to `ThemeCard.__init__()` to support VIP-exclusive themes
- Locked cards display:
  - 50% opacity via `QGraphicsOpacityEffect`
  - Forbidden cursor instead of pointing hand
  - Lock emoji (🔒) appended to theme name
  - Tooltip "VIP 專屬主題" on click instead of emitting `clicked` signal
- Updated `_THEME_META` to mark kraft theme as `'vip_only': True`
- `SettingsWindow` now accepts `is_vip` parameter and passes it to `ThemeCard` instances during initialization

### Main Window Integration (`src/uPtt/ui/screens.py`)
- Added `_is_vip` instance variable to `MainWindow`, set during `on_login_result()`
- Created `_window_title(suffix)` helper method to consistently format title with VIP tag
- Window title now shows "uPtt - {ID} · VIP" for VIP accounts, "uPtt - {ID}" for regular accounts
- VIP status persists across reconnections and is passed to `SettingsWindow` when opened
- Updated all window title assignments to use the new helper method

### Tests (`tests/test_ui_settings.py`, `tests/test_ui_screens.py`, `tests/test_vip.py` - new)
- Added `test_kraft_theme_locked_for_non_vip()` — verifies locked card blocks theme application
- Added `test_kraft_theme_unlocked_for_vip()` — verifies VIP can select kraft theme
- Added `test_on_login_result_title_has_no_vip_tag_for_regular_account()` — window title without VIP tag
- Added `test_on_login_result_title_shows_vip_tag_for_vip_account()` — window title with VIP tag
- New `test_vip.py` module with comprehensive hash-based whitelist tests (case insensitivity, empty/None handling)

## Implementation Details
- VIP determination happens once at login; status is cached in `MainWindow._is_vip` and passed to settings window
- Locked theme cards are visually distinct but remain in the UI (not hidden) to show what's available to VIP users
- Hash-based whitelist approach avoids storing plaintext IDs in source code while remaining lightweight (no backend required)
- All window title updates consolidated through `_window_title()` to ensure consistency across reconnects and state changes

https://claude.ai/code/session_015kfeCvRmxbnqss3ErMJFAN